### PR TITLE
Fix documentation and logo links

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -8,10 +8,10 @@
       "@NewsGuyTor"
     ],
     "iot_class": "cloud_polling",
-    "documentation": "https://github.com/NewsGuyTor/Fellow_Aiden-HomeAssistant/blob/main/README.md",
+    "documentation": "https://github.com/NewsGuyTor/FellowAiden-HomeAssistant/blob/main/README.md",
     "dependencies": [],
     "requirements": [],
     "last_update": "2025-01-21",
-    "logo": "https://raw.githubusercontent.com/NewsGuyTor/Fellow_Aiden-HomeAssistant/main/logo.png"
+    "logo": "https://raw.githubusercontent.com/NewsGuyTor/FellowAiden-HomeAssistant/main/logo.png"
   }
   

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Fellow Aiden",
   "version": "0.3.1",
   "config_flow": true,
-  "documentation": "https://github.com/NewsGuyTor/Fellow_Aiden-HomeAssistant",
+  "documentation": "https://github.com/NewsGuyTor/FellowAiden-HomeAssistant",
   "requirements": [
     "fellow-aiden>=0.0.14"
   ],


### PR DESCRIPTION
## Summary
- point documentation and logo at repository `FellowAiden-HomeAssistant`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f5797a9ec8331a877fce0dd9834a2