### PR TITLE
Add brew_now service + Brew now button (one-off schedule, auto-delete)

### DIFF
--- a/custom_components/fellow/const.py
+++ b/custom_components/fellow/const.py
@@ -1,6 +1,6 @@
 """Constants for Fellow Aiden."""
 DOMAIN = "fellow"
-PLATFORMS = ["sensor", "select", "binary_sensor"]
+PLATFORMS = ["sensor", "select", "binary_sensor", "button"]
 
 # Update intervals
 DEFAULT_UPDATE_INTERVAL_MINUTES = 1

--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -155,6 +155,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
+        return result
 
     async def async_delete_profile(self, profile_id: str) -> None:
         """Delete a brew profile and refresh coordinator data."""
@@ -172,7 +173,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._next_refresh_verbose = True
         await self.async_request_refresh()
 
-    async def async_create_schedule(self, schedule_data: dict[str, Any]) -> None:
+    async def async_create_schedule(self, schedule_data: dict[str, Any]) -> dict[str, Any] | None:
         """Create a new brew schedule and refresh coordinator data."""
         if not self.api:
             raise RuntimeError("Fellow Aiden library not initialized")
@@ -187,6 +188,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
+        return result
 
     async def async_delete_schedule(self, schedule_id: str) -> None:
         """Delete a brew schedule and refresh coordinator data."""

--- a/custom_components/fellow/services.yaml
+++ b/custom_components/fellow/services.yaml
@@ -323,3 +323,54 @@ refresh_and_log_data:
   name: "Refresh and Log Full Data"
   description: "Manually refreshes all data from the Fellow API and logs the complete response."
   fields: {}
+
+brew_now:
+  name: "Brew Now"
+  description: "Schedules a brew to start soon (schedule-now hack) and then deletes the created schedule so it won't accumulate or repeat weekly."
+  fields:
+    amountOfWater:
+      name: "Water Amount (mL)"
+      description: "Amount of water to use for brewing (150-1500 mL)."
+      required: false
+      default: 300
+      selector:
+        number:
+          min: 150
+          max: 1500
+          step: 1
+          unit_of_measurement: "mL"
+          mode: box
+    profileName:
+      name: "Profile Name"
+      description: "Profile name to use. If omitted, uses current selection; otherwise falls back to Light Roast."
+      required: false
+      selector:
+        text:
+    profileId:
+      name: "Profile ID"
+      description: "Profile ID to use (alternative to name)."
+      required: false
+      selector:
+        text:
+    offsetSeconds:
+      name: "Start Delay (seconds)"
+      description: "How far in the future to schedule the brew (default 90s)."
+      required: false
+      default: 90
+      selector:
+        number:
+          min: 30
+          max: 600
+          step: 1
+          mode: box
+    cleanupAfterSeconds:
+      name: "Delete Schedule After (seconds)"
+      description: "How long after creation to delete the created schedule (default 900s)."
+      required: false
+      default: 900
+      selector:
+        number:
+          min: 60
+          max: 3600
+          step: 10
+          mode: box


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Brew Now" service to schedule an immediate brew with customizable water amount, coffee profile selection, start time offset, and automatic schedule cleanup.

* **Chores**
  * Extended platform support to include buttons.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->