### PR TITLE
Fix TypeError in get_average_time_between_brews when sorting timestamps

### DIFF
--- a/custom_components/fellow/brew_history.py
+++ b/custom_components/fellow/brew_history.py
@@ -208,6 +208,9 @@ class BrewHistoryManager:
         for record in self._brew_history:
             try:
                 ts = datetime.fromisoformat(record["timestamp"])
+                # Ensure timezone awareness for comparison
+                if ts.tzinfo is None:
+                    ts = dt_util.as_local(ts)
                 timestamps.append(ts)
             except (ValueError, KeyError):
                 continue


### PR DESCRIPTION
## Problem

`get_average_time_between_brews()` crashes with:

```
TypeError: can't compare offset-naive and offset-aware datetimes
```

Stored brew history timestamps can be a mix of tz-aware and tz-naive strings depending on when they were written. When the method parses them and calls `sort()`, Python can't compare the two kinds.

## Fix

Normalize each parsed timestamp to local tz (via `dt_util.as_local()`) before appending, same pattern the other methods in this file already use (`_clean_old_records`, `get_water_usage_for_period`, `get_brew_count_for_period`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved timestamp handling in brew history calculations to ensure accurate and consistent processing of all brew timestamp data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->