### PR TITLE
Bring integration up to Gold on the HA quality scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,34 +234,6 @@ automation:
 
 ---
 
-## Services
-
-### Brew Profile Management
-
-- **`fellow.create_profile`**: Create new brew profiles with detailed parameters (ratio, bloom, pulses, etc.)
-- **`fellow.delete_profile`**: Delete profiles by ID
-- **`fellow.list_profiles`**: List all available profiles with their names and IDs
-- **`fellow.get_profile_details`**: Get detailed information about a specific profile
-
-### Schedule Management
-
-- **`fellow.create_schedule`**: Create brewing schedules with day/time configurations
-- **`fellow.delete_schedule`**: Delete schedules by ID
-- **`fellow.toggle_schedule`**: Enable or disable existing schedules
-- **`fellow.list_schedules`**: List all current schedules with full details
-
-### Brewing Operations
-
-- *No direct start brew service (use device controls or schedules).*
-
-### Analytics & Debugging
-
-- **`fellow.reset_water_tracking`**: Reset water usage tracking baseline
-- **`fellow.debug_water_usage`**: Show detailed water usage history
-- **`fellow.refresh_and_log_data`**: Manually refresh and log complete API response
-
----
-
 ## FAQ & Troubleshooting
 
 1. **"Device not found"** -- Make sure you have a Fellow Aiden brewer linked to the account you used during setup.

--- a/README.md
+++ b/README.md
@@ -95,16 +95,142 @@ Choose one of the following methods to install the **Fellow Aiden** integration:
 
 ## Configuration
 
-1. **Credentials**  
-   - Enter your email and password for the Fellow Aiden account.  
-   - Home Assistant saves these securely in its config entry.
+### Installation parameters
 
-2. **Polling Interval**  
-   - The integration polls your device every 1 minute by default.  
-   - If your brewer starts complaining about the daily grind, consider adjusting the interval in the options flow (if implemented).
+| Parameter | Description |
+|-----------|-------------|
+| **Email** | The email address for your Fellow Aiden account. |
+| **Password** | Your Fellow account password. |
 
-3. **Optional Services**  
-   - You’ll see **Create Brew Profile** and **Delete Brew Profile** services that let you manage your brewer from automations or the Developer Tools.
+### Options
+
+After installation, go to **Settings > Devices & Services > Fellow Aiden > Configure** to change:
+
+| Option | Default | Range | Description |
+|--------|---------|-------|-------------|
+| Update interval | 60 s | 30-300 s | How often the integration polls the Fellow cloud API. Lower values give faster updates but increase network traffic. |
+
+---
+
+## How data is updated
+
+The integration polls Fellow's cloud API at a configurable interval (default 60 seconds). Each poll fetches the device config, brew profiles, and schedules. Historical brew and water usage data is tracked locally and kept for 365 days.
+
+There is no local/push connection. All data goes through Fellow's servers.
+
+---
+
+## Removal
+
+1. Go to **Settings > Devices & Services**.
+2. Find **Fellow Aiden** and click the three-dot menu.
+3. Click **Delete**.
+
+---
+
+## Supported devices
+
+The **Fellow Aiden** coffee brewer. No other Fellow products are supported.
+
+---
+
+## Supported functionality
+
+### Entities
+
+| Platform | Entity | Description |
+|----------|--------|-------------|
+| Sensor | Total brews | Lifetime brew count. |
+| Sensor | Total water volume | Lifetime water usage in liters. |
+| Sensor | Last brew volume | Water used in the most recent brew (mL). |
+| Sensor | Last brew start/end time | Timestamps of the last brew. |
+| Sensor | Last brew duration | How long the last brew took. |
+| Sensor | Last brew time | When the last brew finished. |
+| Sensor | Water used today/this week/this month | Period water usage from local tracking. |
+| Sensor | Average water per brew | Lifetime average (mL). |
+| Sensor | Average brew duration | Historical average (minutes). |
+| Sensor | Current profile | The active or most recently used brew profile. |
+| Sensor | Basket | Which basket is inserted: single serve, batch, or missing. |
+| Sensor | Chime volume | Device chime setting (diagnostic, disabled by default). |
+| Binary sensor | Brewing | Whether the brewer is running. |
+| Binary sensor | Carafe | Whether the carafe is present. |
+| Binary sensor | Heater | Whether the heater is on. |
+| Binary sensor | Lid | Whether the lid is open. |
+| Binary sensor | Missing water | Whether the water tank is empty. |
+| Select | Profiles | Dropdown of available brew profiles (display-only). |
+
+### Services
+
+| Service | Description |
+|---------|-------------|
+| `fellow.create_profile` | Create a brew profile with full parameter control. |
+| `fellow.delete_profile` | Delete a profile by ID. |
+| `fellow.list_profiles` | List all profiles (returns response data). |
+| `fellow.get_profile_details` | Get full details for one profile. |
+| `fellow.create_schedule` | Create a brewing schedule with day/time/profile. |
+| `fellow.delete_schedule` | Delete a schedule by ID. |
+| `fellow.toggle_schedule` | Enable or disable a schedule. |
+| `fellow.list_schedules` | List all schedules. |
+| `fellow.reset_water_tracking` | Reset the water usage baseline. |
+| `fellow.debug_water_usage` | Dump raw water usage records. |
+| `fellow.refresh_and_log_data` | Force a data refresh and return the API response. |
+
+---
+
+## Automation examples
+
+Notify when a brew finishes:
+
+```yaml
+automation:
+  - alias: "Brew finished notification"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.fellow_aiden_brewer_brewing
+        from: "on"
+        to: "off"
+    action:
+      - service: notify.mobile_app
+        data:
+          title: "Coffee's ready"
+          message: "Your brew just finished."
+```
+
+Log water usage at midnight:
+
+```yaml
+automation:
+  - alias: "Log water usage at midnight"
+    trigger:
+      - platform: time
+        at: "00:00:00"
+    action:
+      - service: logbook.log
+        data:
+          name: "Fellow Aiden"
+          message: >
+            Water today:
+            {{ states('sensor.fellow_aiden_brewer_water_used_today') }} L
+```
+
+---
+
+## Known limitations
+
+- No direct brew start: the Fellow API does not support starting a brew remotely. Use the physical controls or a schedule.
+- Profile selection is display-only: the dropdown shows profiles but selecting one does nothing.
+- Cloud-only: all data comes through Fellow's servers. If their API is down, the integration can't update.
+- Single device per entry: each config entry connects to one brewer. Multiple brewers on the same account are not supported.
+- Vendored library: the Fellow Aiden Python library is vendored from [9b/fellow-aiden](https://github.com/9b/fellow-aiden) and uses synchronous HTTP. The coordinator wraps calls in an executor thread.
+
+---
+
+## Use cases
+
+- **Morning routine**: schedule a brew at 6:30 AM on weekdays and automate kitchen lights when brewing starts.
+- **Water tracking**: monitor daily consumption and alert on unusual spikes.
+- **Profile management**: create and rotate brew profiles from automations.
+- **Brew logging**: track brew frequency, profile usage, and water per brew over time.
 
 ---
 
@@ -134,16 +260,19 @@ Choose one of the following methods to install the **Fellow Aiden** integration:
 - **`fellow.debug_water_usage`**: Show detailed water usage history
 - **`fellow.refresh_and_log_data`**: Manually refresh and log complete API response
 
-All services include error handling and detailed logging for troubleshooting.
-
 ---
 
 ## FAQ & Troubleshooting
 
-1. **It says “Device not found.”**  
-   - Make sure you actually have a Fellow Aiden brewer configured with the same account. That helps.  
-2. **I see “Unknown” for some sensors.**  
-   - Possibly the brewer hasn’t updated yet or the sensor values are missing from the device’s API. Wait a minute or two (literally). Some others may take longer. Make sure to issue a bug report if they've been “Unknown” for days.
+1. **"Device not found"** -- Make sure you have a Fellow Aiden brewer linked to the account you used during setup.
+
+2. **Sensors showing "Unknown"** -- The brewer may not have reported data yet. Wait a few minutes. If it persists for days, file a bug report.
+
+3. **"Authentication failed" after setup** -- Your password may have changed. Go to **Settings > Devices & Services > Fellow Aiden** and use **Reconfigure** to update your credentials.
+
+4. **Diagnostics** -- Download from **Settings > Devices & Services > Fellow Aiden > (device) > Download diagnostics**. Attach to bug reports. Sensitive data (password, MAC addresses, IP) is automatically redacted.
+
+5. **Water usage sensors show 0** -- Water tracking is cumulative and stored locally. If the store was lost, use `fellow.reset_water_tracking` to set a new baseline.
 
 ---
 

--- a/custom_components/fellow/__init__.py
+++ b/custom_components/fellow/__init__.py
@@ -74,21 +74,21 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def handle_create_profile(call: ServiceCall) -> None:
         coordinator = _get_coordinator(hass)
         data = {
-            "profileType": call.data.get("profileType", DEFAULT_PROFILE_TYPE),
+            "profileType": call.data.get("profile_type", DEFAULT_PROFILE_TYPE),
             "title": call.data["title"],
             "ratio": call.data["ratio"],
-            "bloomEnabled": call.data["bloomEnabled"],
-            "bloomRatio": call.data["bloomRatio"],
-            "bloomDuration": call.data["bloomDuration"],
-            "bloomTemperature": call.data["bloomTemperature"],
-            "ssPulsesEnabled": call.data["ssPulsesEnabled"],
-            "ssPulsesNumber": call.data["ssPulsesNumber"],
-            "ssPulsesInterval": call.data["ssPulsesInterval"],
-            "ssPulseTemperatures": call.data["ssPulseTemperatures"],
-            "batchPulsesEnabled": call.data["batchPulsesEnabled"],
-            "batchPulsesNumber": call.data["batchPulsesNumber"],
-            "batchPulsesInterval": call.data["batchPulsesInterval"],
-            "batchPulseTemperatures": call.data["batchPulseTemperatures"],
+            "bloomEnabled": call.data["bloom_enabled"],
+            "bloomRatio": call.data["bloom_ratio"],
+            "bloomDuration": call.data["bloom_duration"],
+            "bloomTemperature": call.data["bloom_temperature"],
+            "ssPulsesEnabled": call.data["ss_pulses_enabled"],
+            "ssPulsesNumber": call.data["ss_pulses_number"],
+            "ssPulsesInterval": call.data["ss_pulses_interval"],
+            "ssPulseTemperatures": call.data["ss_pulse_temperatures"],
+            "batchPulsesEnabled": call.data["batch_pulses_enabled"],
+            "batchPulsesNumber": call.data["batch_pulses_number"],
+            "batchPulsesInterval": call.data["batch_pulses_interval"],
+            "batchPulseTemperatures": call.data["batch_pulse_temperatures"],
         }
         try:
             await coordinator.async_create_profile(data)
@@ -176,7 +176,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def handle_create_schedule(call: ServiceCall) -> None:
         coordinator = _get_coordinator(hass)
-        profile_input = call.data.get("profileName") or call.data.get("profileId")
+        profile_input = call.data.get("profile_name") or call.data.get("profile_id")
         if not profile_input:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
@@ -226,7 +226,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             ],
             "secondFromStartOfTheDay": seconds,
             "enabled": call.data.get("enabled", True),
-            "amountOfWater": call.data["amountOfWater"],
+            "amountOfWater": call.data["amount_of_water"],
             "profileId": profile_id,
         }
         try:

--- a/custom_components/fellow/__init__.py
+++ b/custom_components/fellow/__init__.py
@@ -288,7 +288,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def handle_debug_water_usage(call: ServiceCall) -> ServiceResponse:
         coordinator = _get_coordinator(hass)
-        device_config = coordinator.data.get("device_config", {})
+        device_config = (coordinator.data or {}).get("device_config", {})
         return {
             "water_usage_record_count": coordinator.history_manager.get_water_usage_count(),
             "current_device_total_ml": device_config.get("totalWaterVolumeL", 0),
@@ -299,7 +299,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def handle_reset_water_tracking(call: ServiceCall) -> None:
         coordinator = _get_coordinator(hass)
-        device_config = coordinator.data.get("device_config", {})
+        device_config = (coordinator.data or {}).get("device_config", {})
         current_total = device_config.get("totalWaterVolumeL", 0)
         _LOGGER.info(
             "Resetting water tracking baseline to %d ml (%.2f L)",

--- a/custom_components/fellow/__init__.py
+++ b/custom_components/fellow/__init__.py
@@ -93,7 +93,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         try:
             await coordinator.async_create_profile(data)
         except ValueError as exc:
-            raise ServiceValidationError(str(exc)) from exc
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="create_profile_failed",
+                translation_placeholders={"error": str(exc)},
+            ) from exc
         except Exception as exc:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
@@ -228,7 +232,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         try:
             await coordinator.async_create_schedule(schedule_data)
         except ValueError as exc:
-            raise ServiceValidationError(str(exc)) from exc
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="create_schedule_failed",
+                translation_placeholders={"error": str(exc)},
+            ) from exc
         except Exception as exc:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
@@ -280,12 +288,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def handle_debug_water_usage(call: ServiceCall) -> ServiceResponse:
         coordinator = _get_coordinator(hass)
-        history = coordinator.history_manager._water_usage_history
         device_config = coordinator.data.get("device_config", {})
         return {
-            "water_usage_history": history,
+            "water_usage_record_count": coordinator.history_manager.get_water_usage_count(),
             "current_device_total_ml": device_config.get("totalWaterVolumeL", 0),
-            "last_tracked_total_ml": coordinator.history_manager._last_total_water,
+            "water_usage_today_l": coordinator.history_manager.get_water_usage_for_period(1),
+            "water_usage_week_l": coordinator.history_manager.get_water_usage_for_period(7),
+            "water_usage_month_l": coordinator.history_manager.get_water_usage_for_period(30),
         }
 
     async def handle_reset_water_tracking(call: ServiceCall) -> None:

--- a/custom_components/fellow/__init__.py
+++ b/custom_components/fellow/__init__.py
@@ -1,50 +1,330 @@
-"""Fellow Aiden for Home Assistant."""
+"""Fellow Aiden integration for Home Assistant."""
 from __future__ import annotations
 
 import logging
+import re
 from datetime import time
+from typing import cast
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, ServiceResponse, SupportsResponse
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, PLATFORMS, DEFAULT_PROFILE_TYPE, FellowAidenConfigEntry
 from .coordinator import FellowAidenDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+PROFILE_ID_RE = re.compile(r"^(p|plocal)\d+$")
+
+
+def _get_coordinator(hass: HomeAssistant) -> FellowAidenDataUpdateCoordinator:
+    """Return the coordinator for the first loaded config entry.
+
+    Raises ServiceValidationError when no entry is available or loaded.
+    """
+    entries = hass.config_entries.async_entries(DOMAIN)
+    if not entries:
+        raise ServiceValidationError("No Fellow Aiden integrations configured")
+
+    for entry in entries:
+        if entry.state is ConfigEntryState.LOADED:
+            return cast(FellowAidenConfigEntry, entry).runtime_data
+
+    raise ServiceValidationError(
+        "Fellow Aiden integration is not loaded; check Settings > Integrations"
+    )
+
+
+def _profile_id_by_name(
+    coordinator: FellowAidenDataUpdateCoordinator, name: str
+) -> str | None:
+    """Look up a profile ID by its title. Returns None if not found."""
+    data = coordinator.data
+    if not data or "profiles" not in data:
+        return None
+    for profile in data["profiles"]:
+        if profile.get("title") == name:
+            return profile.get("id")
+    return None
+
+
+def _available_profile_names(
+    coordinator: FellowAidenDataUpdateCoordinator,
+) -> list[str]:
+    data = coordinator.data
+    if not data or "profiles" not in data:
+        return []
+    return [p.get("title", f"Profile {i}") for i, p in enumerate(data["profiles"])]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Register Fellow Aiden services."""
+
+    async def handle_create_profile(call: ServiceCall) -> None:
+        coordinator = _get_coordinator(hass)
+        data = {
+            "profileType": call.data.get("profileType", DEFAULT_PROFILE_TYPE),
+            "title": call.data["title"],
+            "ratio": call.data["ratio"],
+            "bloomEnabled": call.data["bloomEnabled"],
+            "bloomRatio": call.data["bloomRatio"],
+            "bloomDuration": call.data["bloomDuration"],
+            "bloomTemperature": call.data["bloomTemperature"],
+            "ssPulsesEnabled": call.data["ssPulsesEnabled"],
+            "ssPulsesNumber": call.data["ssPulsesNumber"],
+            "ssPulsesInterval": call.data["ssPulsesInterval"],
+            "ssPulseTemperatures": call.data["ssPulseTemperatures"],
+            "batchPulsesEnabled": call.data["batchPulsesEnabled"],
+            "batchPulsesNumber": call.data["batchPulsesNumber"],
+            "batchPulsesInterval": call.data["batchPulsesInterval"],
+            "batchPulseTemperatures": call.data["batchPulseTemperatures"],
+        }
+        try:
+            await coordinator.async_create_profile(data)
+        except ValueError as exc:
+            raise ServiceValidationError(str(exc)) from exc
+        except Exception as exc:
+            raise HomeAssistantError(f"Failed to create profile: {exc}") from exc
+
+    async def handle_delete_profile(call: ServiceCall) -> None:
+        coordinator = _get_coordinator(hass)
+        pid = call.data.get("profile_id")
+        if not pid:
+            raise ServiceValidationError("profile_id is required")
+        try:
+            await coordinator.async_delete_profile(pid)
+        except Exception as exc:
+            raise HomeAssistantError(f"Failed to delete profile: {exc}") from exc
+
+    async def handle_list_profiles(call: ServiceCall) -> ServiceResponse:
+        coordinator = _get_coordinator(hass)
+        data = coordinator.data
+        if not data or "profiles" not in data or not data["profiles"]:
+            return {"profiles": []}
+        return {
+            "profiles": [
+                {
+                    "id": p.get("id"),
+                    "title": p.get("title", "Unnamed Profile"),
+                    "isDefault": p.get("isDefaultProfile", False),
+                }
+                for p in data["profiles"]
+            ]
+        }
+
+    async def handle_get_profile_details(call: ServiceCall) -> ServiceResponse:
+        profile_input = call.data.get("profile_name") or call.data.get("profile_id")
+        if not profile_input:
+            raise ServiceValidationError("Provide profile_name or profile_id")
+
+        coordinator = _get_coordinator(hass)
+        data = coordinator.data
+        if not data or "profiles" not in data:
+            raise ServiceValidationError("No profiles available")
+
+        target = next(
+            (
+                p
+                for p in data["profiles"]
+                if p.get("title") == profile_input or p.get("id") == profile_input
+            ),
+            None,
+        )
+        if not target:
+            names = [p.get("title", "Unnamed") for p in data["profiles"]]
+            raise ServiceValidationError(
+                "Profile '{}' not found. Available: {}".format(
+                    profile_input, ", ".join(names)
+                )
+            )
+        return {"profile": target}
+
+    async def handle_create_schedule(call: ServiceCall) -> None:
+        coordinator = _get_coordinator(hass)
+        profile_input = call.data.get("profileName") or call.data.get("profileId")
+        if not profile_input:
+            raise ServiceValidationError("Provide profileName or profileId")
+
+        profile_id = _profile_id_by_name(coordinator, profile_input)
+        if not profile_id:
+            if PROFILE_ID_RE.match(profile_input):
+                profile_id = profile_input
+            else:
+                names = _available_profile_names(coordinator)
+                raise ServiceValidationError(
+                    "Profile '{}' not found. Available: {}".format(
+                        profile_input, ", ".join(names)
+                    )
+                )
+
+        time_str: str | None = call.data.get("time")
+        if not time_str:
+            raise ServiceValidationError("'time' is required")
+        try:
+            time_obj = time.fromisoformat(time_str)
+        except ValueError as exc:
+            raise ServiceValidationError(
+                f"Bad time format: '{time_str}'. Use HH:MM:SS."
+            ) from exc
+
+        seconds = time_obj.hour * 3600 + time_obj.minute * 60 + time_obj.second
+        schedule_data = {
+            "days": [
+                call.data.get("sunday", False),
+                call.data.get("monday", False),
+                call.data.get("tuesday", False),
+                call.data.get("wednesday", False),
+                call.data.get("thursday", False),
+                call.data.get("friday", False),
+                call.data.get("saturday", False),
+            ],
+            "secondFromStartOfTheDay": seconds,
+            "enabled": call.data.get("enabled", True),
+            "amountOfWater": call.data["amountOfWater"],
+            "profileId": profile_id,
+        }
+        try:
+            await coordinator.async_create_schedule(schedule_data)
+        except ValueError as exc:
+            raise ServiceValidationError(str(exc)) from exc
+        except Exception as exc:
+            raise HomeAssistantError(f"Failed to create schedule: {exc}") from exc
+
+    async def handle_delete_schedule(call: ServiceCall) -> None:
+        coordinator = _get_coordinator(hass)
+        sid = call.data.get("schedule_id")
+        if not sid:
+            raise ServiceValidationError("schedule_id is required")
+        try:
+            await coordinator.async_delete_schedule(sid)
+        except Exception as exc:
+            raise HomeAssistantError(f"Failed to delete schedule: {exc}") from exc
+
+    async def handle_toggle_schedule(call: ServiceCall) -> None:
+        coordinator = _get_coordinator(hass)
+        sid = call.data.get("schedule_id")
+        if not sid:
+            raise ServiceValidationError("schedule_id is required")
+        enabled = call.data.get("enabled", True)
+        try:
+            await coordinator.async_toggle_schedule(sid, enabled)
+        except Exception as exc:
+            raise HomeAssistantError(f"Failed to toggle schedule: {exc}") from exc
+
+    async def handle_list_schedules(call: ServiceCall) -> ServiceResponse:
+        coordinator = _get_coordinator(hass)
+        await coordinator.async_request_refresh()
+        data = coordinator.data
+        schedules = data.get("schedules", []) if data else []
+        return {"schedules": schedules}
+
+    async def handle_debug_water_usage(call: ServiceCall) -> ServiceResponse:
+        coordinator = _get_coordinator(hass)
+        history = coordinator.history_manager._water_usage_history
+        device_config = coordinator.data.get("device_config", {})
+        return {
+            "water_usage_history": history,
+            "current_device_total_ml": device_config.get("totalWaterVolumeL", 0),
+            "last_tracked_total_ml": coordinator.history_manager._last_total_water,
+        }
+
+    async def handle_reset_water_tracking(call: ServiceCall) -> None:
+        coordinator = _get_coordinator(hass)
+        device_config = coordinator.data.get("device_config", {})
+        current_total = device_config.get("totalWaterVolumeL", 0)
+        _LOGGER.info(
+            "Resetting water tracking baseline to %d ml (%.2f L)",
+            current_total,
+            current_total / 1000.0,
+        )
+        try:
+            await coordinator.history_manager.async_reset_water_tracking(current_total)
+        except Exception as exc:
+            raise HomeAssistantError(
+                f"Failed to reset water tracking: {exc}"
+            ) from exc
+
+    async def handle_refresh_and_log_data(call: ServiceCall) -> ServiceResponse:
+        coordinator = _get_coordinator(hass)
+        coordinator._next_refresh_verbose = True
+        await coordinator.async_request_refresh()
+        data = coordinator.data
+        return data if data else {"error": "No data available after refresh"}
+
+    hass.services.async_register(
+        DOMAIN, "create_profile", handle_create_profile, schema=None
+    )
+    hass.services.async_register(
+        DOMAIN, "delete_profile", handle_delete_profile, schema=None
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "list_profiles",
+        handle_list_profiles,
+        schema=None,
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "get_profile_details",
+        handle_get_profile_details,
+        schema=None,
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN, "create_schedule", handle_create_schedule, schema=None
+    )
+    hass.services.async_register(
+        DOMAIN, "delete_schedule", handle_delete_schedule, schema=None
+    )
+    hass.services.async_register(
+        DOMAIN, "toggle_schedule", handle_toggle_schedule, schema=None
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "list_schedules",
+        handle_list_schedules,
+        schema=None,
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "debug_water_usage",
+        handle_debug_water_usage,
+        schema=None,
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN, "reset_water_tracking", handle_reset_water_tracking, schema=None
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "refresh_and_log_data",
+        handle_refresh_and_log_data,
+        schema=None,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: FellowAidenConfigEntry) -> bool:
     """Set up Fellow Aiden from a config entry."""
-    _LOGGER.info(f"Setting up Fellow Aiden integration for entry {entry.entry_id}")
-
-    email = entry.data["email"]
-    password = entry.data["password"]
-    _LOGGER.debug(f"Using email: {email}")
-
-    _LOGGER.debug("Creating coordinator")
-    coordinator = FellowAidenDataUpdateCoordinator(hass, entry, email, password)
-
-    _LOGGER.debug("Performing first refresh")
+    coordinator = FellowAidenDataUpdateCoordinator(
+        hass, entry, entry.data["email"], entry.data["password"]
+    )
     await coordinator.async_config_entry_first_refresh()
-    _LOGGER.debug(f"First refresh completed, data available: {coordinator.data is not None}")
-
     entry.runtime_data = coordinator
 
-    # Forward platforms (sensor, etc.) and register services
-    _LOGGER.debug(f"Forwarding platforms: {PLATFORMS}")
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    # Only register services once, not per config entry
-    if not hass.services.has_service(DOMAIN, "create_profile"):
-        _LOGGER.debug("Registering services")
-        async_register_services(hass)
-    else:
-        _LOGGER.debug("Services already registered, skipping")
-
-    # Set up options update listener
-    entry.async_on_unload(entry.add_update_listener(async_update_options))
-
-    _LOGGER.info("Fellow Aiden integration setup completed successfully")
+    entry.async_on_unload(entry.add_update_listener(_async_update_options))
     return True
 
 
@@ -53,384 +333,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: FellowAidenConfigEntry)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def async_update_options(hass: HomeAssistant, entry: FellowAidenConfigEntry) -> None:
-    """Update options when they change."""
-    _LOGGER.debug("Options updated, reloading integration to apply new update interval")
+async def _async_update_options(hass: HomeAssistant, entry: FellowAidenConfigEntry) -> None:
+    """Reload the integration when options change."""
     await hass.config_entries.async_reload(entry.entry_id)
-
-
-def async_register_services(hass: HomeAssistant) -> None:
-    """Register services for creating or deleting profiles.
-
-    Note: Currently uses the first available coordinator for multi-device setups.
-    TODO: Add entry_id/entity_id parameter support to target specific devices.
-    """
-
-    def get_coordinator(entry_id: str | None = None) -> FellowAidenDataUpdateCoordinator:
-        """Get a coordinator from hass data.
-
-        Args:
-            entry_id: Optional config entry ID. If None, returns the first available.
-
-        Returns:
-            The coordinator for the specified or first available entry.
-
-        Raises:
-            ValueError: If no integrations are configured or entry_id is invalid.
-        """
-        entries = hass.config_entries.async_entries(DOMAIN)
-        if not entries:
-            raise ValueError("No Fellow Aiden integrations configured")
-
-        if entry_id is not None:
-            entry = hass.config_entries.async_get_entry(entry_id)
-            if entry is None or entry.domain != DOMAIN:
-                available = [e.entry_id for e in entries]
-                raise ValueError(
-                    f"Entry ID '{entry_id}' not found. Available entries: {available}"
-                )
-            return entry.runtime_data
-
-        # Single-device fallback: use the first loaded entry
-        return entries[0].runtime_data
-
-    def get_profile_id_by_name(profile_name: str, entry_id: str | None = None) -> str | None:
-        """Get profile ID by profile name.
-
-        Args:
-            profile_name: The name of the profile to find.
-            entry_id: Optional config entry ID to search within.
-        """
-        coordinator = get_coordinator(entry_id)
-        data = coordinator.data
-        if not data or "profiles" not in data:
-            return None
-
-        for profile in data["profiles"]:
-            if profile.get("title") == profile_name:
-                return profile.get("id")
-        return None
-
-    def get_available_profile_names(entry_id: str | None = None) -> list[str]:
-        """Get list of available profile names.
-
-        Args:
-            entry_id: Optional config entry ID to get profiles from.
-        """
-        coordinator = get_coordinator(entry_id)
-        data = coordinator.data
-        if not data or "profiles" not in data:
-            return []
-        return [p.get("title", f"Profile {i}") for i, p in enumerate(data["profiles"])]
-
-    async def async_create_profile(call) -> None:
-        """Create a brew profile on the Aiden device."""
-        try:
-            coordinator = get_coordinator()
-            data = {
-                "profileType": call.data.get("profileType", DEFAULT_PROFILE_TYPE),
-                "title": call.data["title"],
-                "ratio": call.data["ratio"],
-                "bloomEnabled": call.data["bloomEnabled"],
-                "bloomRatio": call.data["bloomRatio"],
-                "bloomDuration": call.data["bloomDuration"],
-                "bloomTemperature": call.data["bloomTemperature"],
-                "ssPulsesEnabled": call.data["ssPulsesEnabled"],
-                "ssPulsesNumber": call.data["ssPulsesNumber"],
-                "ssPulsesInterval": call.data["ssPulsesInterval"],
-                "ssPulseTemperatures": call.data["ssPulseTemperatures"],
-                "batchPulsesEnabled": call.data["batchPulsesEnabled"],
-                "batchPulsesNumber": call.data["batchPulsesNumber"],
-                "batchPulsesInterval": call.data["batchPulsesInterval"],
-                "batchPulseTemperatures": call.data["batchPulseTemperatures"],
-            }
-            _LOGGER.debug("Creating profile with data: %s", data)
-            await coordinator.async_create_profile(data)
-            _LOGGER.info("Profile created successfully")
-        except ValueError as e:
-            _LOGGER.error("Validation failed when creating profile: %s", e)
-            raise ServiceValidationError(str(e)) from e
-        except Exception as e:
-            _LOGGER.error("Failed to create profile: %s", e)
-            raise
-
-    async def async_delete_profile(call) -> None:
-        """Delete a brew profile on the Aiden device by ID."""
-        try:
-            coordinator = get_coordinator()
-            pid = call.data.get("profile_id")
-            if not pid:
-                raise ServiceValidationError("profile_id is required")
-            _LOGGER.debug("Deleting profile with ID: %s", pid)
-            await coordinator.async_delete_profile(pid)
-            _LOGGER.info("Profile deleted successfully")
-        except Exception as e:
-            _LOGGER.error("Failed to delete profile: %s", e)
-            raise
-
-    async def async_create_schedule(call) -> None:
-        """Create a brew schedule on the Aiden device."""
-        try:
-            # Handle profile name to ID conversion
-            profile_input = call.data.get("profileName", call.data.get("profileId"))
-            if not profile_input:
-                raise ValueError("Either profileName or profileId must be provided")
-
-            # Try to get profile ID by name first, fall back to direct ID
-            profile_id = get_profile_id_by_name(profile_input)
-            if not profile_id:
-                # Assume it's already an ID - validate format
-                import re
-                profile_id_regex = re.compile(r'^(p|plocal)\d+$')
-                if profile_id_regex.match(profile_input):
-                    profile_id = profile_input  # Use the provided ID
-                else:
-                    available_names = get_available_profile_names()
-                    raise ValueError(f"Profile '{profile_input}' not found. Available profiles: {', '.join(available_names)}")
-
-            # Get the time string from the service call
-            time_str: str | None = call.data.get("time")
-            if not time_str:
-                raise ValueError("'time' must be provided for the schedule")
-
-            # Parse the string into a time object
-            try:
-                time_obj = time.fromisoformat(time_str)
-            except ValueError as e:
-                raise ServiceValidationError(f"Invalid time format: '{time_str}'. Please use HH:MM:SS format.") from e
-
-            seconds_from_start_of_day = (
-                time_obj.hour * 3600 + time_obj.minute * 60 + time_obj.second
-            )
-
-            data = {
-                "days": [
-                    call.data.get("sunday", False),
-                    call.data.get("monday", False),
-                    call.data.get("tuesday", False),
-                    call.data.get("wednesday", False),
-                    call.data.get("thursday", False),
-                    call.data.get("friday", False),
-                    call.data.get("saturday", False),
-                ],
-                "secondFromStartOfTheDay": seconds_from_start_of_day,
-                "enabled": call.data.get("enabled", True),
-                "amountOfWater": call.data["amountOfWater"],
-                "profileId": profile_id,
-            }
-            coordinator = get_coordinator()
-            _LOGGER.debug("Creating schedule with data: %s", data)
-            await coordinator.async_create_schedule(data)
-            _LOGGER.info("Schedule created successfully")
-        except ValueError as e:
-            _LOGGER.error("Validation failed when creating schedule: %s", e)
-            raise ServiceValidationError(str(e)) from e
-        except Exception as e:
-            _LOGGER.error("Failed to create schedule: %s", e)
-            raise
-
-    async def async_delete_schedule(call) -> None:
-        """Delete a brew schedule on the Aiden device by ID."""
-        try:
-            coordinator = get_coordinator()
-            sid = call.data.get("schedule_id")
-            if not sid:
-                raise ServiceValidationError("schedule_id is required")
-            _LOGGER.debug("Deleting schedule with ID: %s", sid)
-            await coordinator.async_delete_schedule(sid)
-            _LOGGER.info("Schedule deleted successfully")
-        except Exception as e:
-            _LOGGER.error("Failed to delete schedule: %s", e)
-            raise
-
-    async def async_toggle_schedule(call) -> None:
-        """Enable or disable a brew schedule on the Aiden device."""
-        try:
-            coordinator = get_coordinator()
-            sid = call.data.get("schedule_id")
-            if not sid:
-                raise ServiceValidationError("schedule_id is required")
-            enabled = call.data.get("enabled", True)
-            _LOGGER.debug("Toggling schedule %s to enabled=%s", sid, enabled)
-            await coordinator.async_toggle_schedule(sid, enabled)
-            _LOGGER.info("Schedule toggled successfully")
-        except Exception as e:
-            _LOGGER.error("Failed to toggle schedule: %s", e)
-            raise
-
-
-    async def async_list_profiles(call) -> ServiceResponse:
-        """List all available profiles with names and IDs."""
-        coordinator = get_coordinator()
-        data = coordinator.data
-        if not data or "profiles" not in data or not data["profiles"]:
-            _LOGGER.info("No profiles available")
-            return {"profiles": []}
-
-        profiles_info = [
-            {
-                "id": profile.get("id"),
-                "title": profile.get("title", "Unnamed Profile"),
-                "isDefault": profile.get("isDefaultProfile", False),
-            }
-            for profile in data["profiles"]
-        ]
-
-        _LOGGER.info(f"Returning {len(profiles_info)} profiles as service response.")
-        return {"profiles": profiles_info}
-
-    async def async_get_profile_details(call) -> ServiceResponse:
-        """Get detailed information about a specific profile."""
-        profile_input = call.data.get("profile_name", call.data.get("profile_id"))
-        if not profile_input:
-            _LOGGER.error("Either profile_name or profile_id must be provided")
-            return {"error": "Either profile_name or profile_id must be provided"}
-
-        coordinator = get_coordinator()
-        data = coordinator.data
-        if not data or "profiles" not in data or not data["profiles"]:
-            _LOGGER.error("No profiles available")
-            return {"error": "No profiles available"}
-
-        # Find the profile
-        target_profile = next(
-            (
-                profile for profile in data["profiles"]
-                if profile.get("title") == profile_input or profile.get("id") == profile_input
-            ),
-            None,
-        )
-
-        if not target_profile:
-            available_names = [p.get("title", "Unnamed") for p in data["profiles"]]
-            _LOGGER.error(f"Profile '{profile_input}' not found. Available: {', '.join(available_names)}")
-            return {"error": f"Profile '{profile_input}' not found"}
-
-        _LOGGER.info(f"Returning details for profile '{target_profile.get('title', 'Unnamed')}'")
-        return {"profile": target_profile}
-
-    async def async_debug_water_usage(call) -> ServiceResponse:
-        """Debug water usage history by returning all records."""
-        _LOGGER.info("=== Returning Water Usage Debug Information ===")
-        coordinator = get_coordinator()
-
-        history = coordinator.history_manager._water_usage_history
-        device_config = coordinator.data.get("device_config", {})
-        current_total = device_config.get("totalWaterVolumeL", 0)
-
-        return {
-            "water_usage_history": history,
-            "current_device_total_ml": current_total,
-            "last_tracked_total_ml": coordinator.history_manager._last_total_water,
-        }
-
-    async def async_reset_water_tracking(call) -> None:
-        """Reset water usage tracking to current device total."""
-        try:
-            _LOGGER.info("=== Resetting Water Usage Tracking ===")
-            coordinator = get_coordinator()
-
-            # Get current device water total
-            device_config = coordinator.data.get("device_config", {})
-            current_total = device_config.get("totalWaterVolumeL", 0)
-
-            _LOGGER.info(f"Resetting baseline to current device total: {current_total}ml ({current_total/1000.0:.2f}L)")
-
-            # Reset the tracking
-            await coordinator.history_manager.async_reset_water_tracking(current_total)
-
-            _LOGGER.info("Water usage tracking reset complete. Period-specific sensors should now show 0.0L until new usage is detected.")
-        except Exception as e:
-            _LOGGER.error("Failed to reset water tracking: %s", e)
-            raise
-
-    async def async_list_schedules(call) -> ServiceResponse:
-        """List all available schedules with their details."""
-        try:
-            coordinator = get_coordinator()
-            # Force a refresh to get latest schedules data
-            await coordinator.async_request_refresh()
-
-            data = coordinator.data
-            schedules = data.get("schedules", []) if data else []
-
-            _LOGGER.info(f"Returning {len(schedules)} schedules as service response.")
-            return {"schedules": schedules}
-
-        except Exception as e:
-            _LOGGER.error("Failed to list schedules: %s", e)
-            return {"error": f"Failed to list schedules: {e}"}
-
-    async def async_refresh_and_log_data(call) -> ServiceResponse:
-        """Manually refresh data and log full API response."""
-        try:
-            _LOGGER.info("=== Manual Data Refresh Requested ===")
-            coordinator = get_coordinator()
-
-            # Enable verbose logging for the next refresh
-            coordinator._next_refresh_verbose = True
-
-            # Use the public refresh API to trigger entity updates and state listeners
-            await coordinator.async_request_refresh()
-
-            # Return the refreshed data from the coordinator
-            data = coordinator.data
-            _LOGGER.info("Manual refresh completed - returning full API response.")
-            return data if data else {"error": "No data available after refresh"}
-        except Exception as e:
-            _LOGGER.error("Failed to refresh and log data: %s", e)
-            return {"error": f"Failed to refresh and log data: {e}"}
-
-    hass.services.async_register(
-        DOMAIN, "create_profile", async_create_profile, schema=None
-    )
-    hass.services.async_register(
-        DOMAIN, "delete_profile", async_delete_profile, schema=None
-    )
-    hass.services.async_register(
-        DOMAIN, "create_schedule", async_create_schedule, schema=None
-    )
-    hass.services.async_register(
-        DOMAIN, "delete_schedule", async_delete_schedule, schema=None
-    )
-    hass.services.async_register(
-        DOMAIN, "toggle_schedule", async_toggle_schedule, schema=None
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "list_profiles",
-        async_list_profiles,
-        schema=None,
-        supports_response=SupportsResponse.ONLY,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "get_profile_details",
-        async_get_profile_details,
-        schema=None,
-        supports_response=SupportsResponse.ONLY,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "debug_water_usage",
-        async_debug_water_usage,
-        schema=None,
-        supports_response=SupportsResponse.ONLY,
-    )
-    hass.services.async_register(
-        DOMAIN, "reset_water_tracking", async_reset_water_tracking, schema=None
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "list_schedules",
-        async_list_schedules,
-        schema=None,
-        supports_response=SupportsResponse.ONLY,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        "refresh_and_log_data",
-        async_refresh_and_log_data,
-        schema=None,
-        supports_response=SupportsResponse.ONLY,
-    )

--- a/custom_components/fellow/base_entity.py
+++ b/custom_components/fellow/base_entity.py
@@ -1,16 +1,19 @@
 """Base entity for Fellow Aiden."""
 from __future__ import annotations
 
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN
+
 
 class FellowAidenBaseEntity(CoordinatorEntity):
     """Base class for all Fellow Aiden entities, attaching them to one device."""
 
+    _attr_has_entity_name = True
+
     @property
-    def device_info(self) -> dict:
+    def device_info(self) -> DeviceInfo:
         """Return device info for the brewer device registry."""
         data = self.coordinator.data or {}
         device_config = data.get("device_config", {})
@@ -19,43 +22,22 @@ class FellowAidenBaseEntity(CoordinatorEntity):
         fw_version = device_config.get("firmwareVersion")
         wifi_mac = device_config.get("wifiMacAddress")
         bt_mac = device_config.get("btMacAddress")
-        wifi_ssid = device_config.get("wifiSSID")
 
-        # We store "elevation" in hw_version to preserve an interesting detail
-        elevation = device_config.get("elevation")  # originally a sensor
+        elevation = device_config.get("elevation")
         hw_version = f"{elevation}m elevation" if elevation is not None else None
 
-        connections = set()
+        connections: set[tuple[str, str]] = set()
         if wifi_mac:
-            connections.add((dr.CONNECTION_NETWORK_MAC, wifi_mac))
+            connections.add((CONNECTION_NETWORK_MAC, wifi_mac))
         if bt_mac:
-            connections.add((dr.CONNECTION_BLUETOOTH, bt_mac))
-        # Add WiFi SSID to device info (namespaced to avoid collisions)
-        if wifi_ssid:
-            connections.add((f"{DOMAIN}:wifi_ssid", wifi_ssid))
+            connections.add((CONNECTION_BLUETOOTH, bt_mac))
 
-        return {
-            "identifiers": {(DOMAIN, brewer_id)},
-            "name": data.get("brewer_name", "Fellow Aiden Brewer"),
-            "manufacturer": "Fellow",
-            "model": "Aiden",
-            "sw_version": fw_version,
-            "hw_version": hw_version,
-            "connections": connections,
-        }
-
-    @property
-    def extra_state_attributes(self) -> dict:
-        """
-        Return extra attributes for this entity, for any
-        additional info that doesn't fit in device_info.
-        """
-        data = self.coordinator.data or {}
-        device_config = data.get("device_config", {})
-        attrs: dict[str, str] = {}
-
-        # Expose local IP if available
-        if "localIpAddress" in device_config:
-            attrs["local_ip_address"] = device_config["localIpAddress"]
-
-        return attrs
+        return DeviceInfo(
+            identifiers={(DOMAIN, brewer_id)},
+            name=data.get("brewer_name", "Fellow Aiden Brewer"),
+            manufacturer="Fellow",
+            model="Aiden",
+            sw_version=fw_version,
+            hw_version=hw_version,
+            connections=connections,
+        )

--- a/custom_components/fellow/binary_sensor.py
+++ b/custom_components/fellow/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, FellowAidenConfigEntry
 from .coordinator import FellowAidenDataUpdateCoordinator
 from .base_entity import FellowAidenBaseEntity
 
@@ -31,11 +31,11 @@ BINARY_SENSORS = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: FellowAidenConfigEntry,
     async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Fellow Aiden binary sensors and the combined 'Basket' sensor."""
-    coordinator: FellowAidenDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     binary_entities: list[FellowAidenBinarySensor] = []
     for key, device_class, name in BINARY_SENSORS:

--- a/custom_components/fellow/binary_sensor.py
+++ b/custom_components/fellow/binary_sensor.py
@@ -7,7 +7,6 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorDeviceClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -58,7 +57,7 @@ class FellowAidenBinarySensor(FellowAidenBaseEntity, BinarySensorEntity):
     def __init__(
         self,
         coordinator: FellowAidenDataUpdateCoordinator,
-        entry: ConfigEntry,
+        entry: FellowAidenConfigEntry,
         key: str,
         translation_key: str,
         device_class: BinarySensorDeviceClass | None,

--- a/custom_components/fellow/binary_sensor.py
+++ b/custom_components/fellow/binary_sensor.py
@@ -17,6 +17,8 @@ from .base_entity import FellowAidenBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 # (api_key, device_class, translation_key)
 BINARY_SENSORS = [
     ("brewing", BinarySensorDeviceClass.RUNNING, "brewing"),

--- a/custom_components/fellow/binary_sensor.py
+++ b/custom_components/fellow/binary_sensor.py
@@ -22,8 +22,8 @@ PARALLEL_UPDATES = 0
 # (api_key, device_class, translation_key)
 BINARY_SENSORS = [
     ("brewing", BinarySensorDeviceClass.RUNNING, "brewing"),
-    ("carafePresent", None, "carafe_inserted"),
-    ("heaterOn", None, "heater"),
+    ("carafePresent", BinarySensorDeviceClass.PRESENCE, "carafe_inserted"),
+    ("heaterOn", BinarySensorDeviceClass.HEAT, "heater"),
     ("lidClosed", BinarySensorDeviceClass.DOOR, "lid"),
     ("missingWater", BinarySensorDeviceClass.PROBLEM, "missing_water"),
 ]

--- a/custom_components/fellow/binary_sensor.py
+++ b/custom_components/fellow/binary_sensor.py
@@ -7,124 +7,82 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorDeviceClass,
 )
-from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, FellowAidenConfigEntry
+from .const import FellowAidenConfigEntry
 from .coordinator import FellowAidenDataUpdateCoordinator
 from .base_entity import FellowAidenBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+# (api_key, device_class, translation_key)
 BINARY_SENSORS = [
-    # (key_in_device_config, device_class, friendly_name)
-    ("brewing", BinarySensorDeviceClass.RUNNING, "Brewing"),
-    ("carafePresent", None, "Carafe Inserted"),
-    ("heaterOn", None, "Heater On"),
-    # lidClosed inverts for DOOR logic:
-    ("lidClosed", BinarySensorDeviceClass.DOOR, "Lid"),
-    ("missingWater", BinarySensorDeviceClass.PROBLEM, "Missing Water"),
+    ("brewing", BinarySensorDeviceClass.RUNNING, "brewing"),
+    ("carafePresent", None, "carafe_inserted"),
+    ("heaterOn", None, "heater"),
+    ("lidClosed", BinarySensorDeviceClass.DOOR, "lid"),
+    ("missingWater", BinarySensorDeviceClass.PROBLEM, "missing_water"),
 ]
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: FellowAidenConfigEntry,
-    async_add_entities: AddEntitiesCallback
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Fellow Aiden binary sensors and the combined 'Basket' sensor."""
+    """Set up Fellow Aiden binary sensors."""
     coordinator = entry.runtime_data
 
-    binary_entities: list[FellowAidenBinarySensor] = []
-    for key, device_class, name in BINARY_SENSORS:
-        binary_entities.append(
+    entities: list[FellowAidenBinarySensor] = []
+    for key, device_class, translation_key in BINARY_SENSORS:
+        entities.append(
             FellowAidenBinarySensor(
                 coordinator=coordinator,
                 entry=entry,
                 key=key,
-                name=name,
-                device_class=device_class
+                translation_key=translation_key,
+                device_class=device_class,
             )
         )
 
-    basket_sensor = AidenBasketSensor(coordinator, entry)
-
-    async_add_entities(binary_entities + [basket_sensor], True)
+    async_add_entities(entities, True)
 
 
 class FellowAidenBinarySensor(FellowAidenBaseEntity, BinarySensorEntity):
-    """Binary sensor for a boolean value from the device_config."""
+    """Binary sensor for a boolean value from the device config."""
 
     def __init__(
         self,
         coordinator: FellowAidenDataUpdateCoordinator,
         entry: ConfigEntry,
         key: str,
-        name: str,
-        device_class: BinarySensorDeviceClass | None
+        translation_key: str,
+        device_class: BinarySensorDeviceClass | None,
     ) -> None:
         super().__init__(coordinator)
         self._entry_id = entry.entry_id
         self._key = key
-        self._attr_name = f"Aiden {name}"
+        self._attr_translation_key = translation_key
         self._attr_unique_id = f"{entry.entry_id}-{key}"
         self._attr_device_class = device_class
 
     @property
     def is_on(self) -> bool | None:
-        """
-        Return True if the sensor is active, else False.
+        """Return True if active.
 
-        For 'lidClosed' with device_class=DOOR:
-          - Home Assistant expects True => Open
-          - But the data returns True => physically closed.
-          => We invert if key == 'lidClosed'.
+        For lidClosed the API returns True when the lid is physically
+        closed, but HA's DOOR class expects True to mean "open".
+        We invert the value for that key.
         """
         data = self.coordinator.data or {}
         device_config = data.get("device_config", {})
         raw_value = device_config.get(self._key)
 
         if self._key == "lidClosed":
-            # Invert: if lidClosed=True => physically closed => HA expects 'off'
-            # Treat None as False (lid open) for safety
             if raw_value is None:
                 return None
             return not raw_value
 
         return raw_value
-
-
-class AidenBasketSensor(FellowAidenBaseEntity, SensorEntity):
-    """
-    A text-based sensor that shows whether the brewer has a single brew basket,
-    a batch brew basket, or no basket present.
-    """
-
-    def __init__(self, coordinator: FellowAidenDataUpdateCoordinator, entry: ConfigEntry) -> None:
-        super().__init__(coordinator)
-        self._entry_id = entry.entry_id
-        self._attr_name = "Aiden Basket"
-        self._attr_unique_id = f"{entry.entry_id}-basket"
-        self._attr_icon = "mdi:basket"  # or any icon you prefer
-
-    @property
-    def native_value(self) -> str:
-        """
-        Possible states:
-          - "Single Serve"
-          - "Batch Brew"
-          - "Missing"
-        """
-        data = self.coordinator.data or {}
-        device_config = data.get("device_config", {})
-        single_basket = device_config.get("singleBrewBasketPresent", False)
-        batch_basket = device_config.get("batchBrewBasketPresent", False)
-
-        if single_basket:
-            return "Single Serve"
-        elif batch_basket:
-            return "Batch Brew"
-        else:
-            return "Missing"

--- a/custom_components/fellow/brew_history.py
+++ b/custom_components/fellow/brew_history.py
@@ -335,16 +335,16 @@ class BrewHistoryManager:
     
     def debug_water_usage_history(self) -> None:
         """Debug method to log all water usage history."""
-        _LOGGER.info(f"Water usage history ({len(self._water_usage_history)} records):")
+        _LOGGER.info("Water usage history (%d records):", len(self._water_usage_history))
         for i, record in enumerate(self._water_usage_history):
             timestamp = record.get("timestamp", "Unknown")
             water_used = record.get("water_used_ml", 0)
             total_at_time = record.get("total_water_at_time", 0)
-            _LOGGER.info(f"  {i+1}. {timestamp}: +{water_used}ml (total: {total_at_time}ml)")
+            _LOGGER.info("  %d. %s: +%sml (total: %sml)", i+1, timestamp, water_used, total_at_time)
         
         if not self._water_usage_history:
             _LOGGER.info("  No water usage records found")
-            _LOGGER.info(f"  Current tracking state: last_total_water={self._last_total_water}")
+            _LOGGER.info("  Current tracking state: last_total_water=%s", self._last_total_water)
     
     async def async_reset_water_tracking(self, current_total_water: int) -> None:
         """Reset water usage tracking with a new baseline."""

--- a/custom_components/fellow/config_flow.py
+++ b/custom_components/fellow/config_flow.py
@@ -2,106 +2,178 @@
 from __future__ import annotations
 
 import logging
+from typing import Any, Mapping
+
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import callback
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.selector import TextSelector, TextSelectorConfig, TextSelectorType
 
 from .fellow_aiden import FellowAiden
-
 from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL_MINUTES, MIN_UPDATE_INTERVAL_SECONDS
 
 _LOGGER = logging.getLogger(__name__)
+
+USER_SCHEMA = vol.Schema(
+    {
+        vol.Required("email"): TextSelector(TextSelectorConfig(type=TextSelectorType.EMAIL)),
+        vol.Required("password"): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+    }
+)
+
+
+def _try_login(email: str, password: str) -> None:
+    """Attempt to authenticate. Raises on failure."""
+    FellowAiden(email, password)
+
 
 class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Fellow Aiden."""
 
     VERSION = 1
 
-    async def async_step_user(self, user_input=None):
-        """Handle the initial user step."""
-        errors = {}
+    _reauth_email: str | None = None
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial setup step."""
+        errors: dict[str, str] = {}
         if user_input is not None:
             email = user_input["email"]
             password = user_input["password"]
-            # Try authenticating (blocking) in executor
             try:
-                await self.hass.async_add_executor_job(FellowAiden, email, password)
+                await self.hass.async_add_executor_job(_try_login, email, password)
             except Exception:
-                # Log with traceback for unexpected errors
-                _LOGGER.exception("Error authenticating")
+                _LOGGER.exception("Authentication failed")
                 errors["base"] = "auth"
             else:
-                # Set unique_id based on email to prevent duplicate entries
                 await self.async_set_unique_id(email.lower())
                 self._abort_if_unique_id_configured()
-
-                # Success, create an entry
                 return self.async_create_entry(
                     title=f"Fellow Aiden ({email})",
-                    data={
-                        "email": email,
-                        "password": password
-                    },
+                    data={"email": email, "password": password},
                 )
 
-        data_schema = vol.Schema({
-            vol.Required("email"): cv.string,
-            vol.Required("password"): cv.string,
-        })
+        return self.async_show_form(
+            step_id="user", data_schema=USER_SCHEMA, errors=errors
+        )
+
+    # -- Reauthentication ---------------------------------------------------
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle a reauth trigger (credentials expired)."""
+        self._reauth_email = entry_data["email"]
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Ask the user for a new password."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            password = user_input["password"]
+            assert self._reauth_email is not None
+            try:
+                await self.hass.async_add_executor_job(
+                    _try_login, self._reauth_email, password
+                )
+            except Exception:
+                _LOGGER.exception("Re-authentication failed")
+                errors["base"] = "auth"
+            else:
+                await self.async_set_unique_id(self._reauth_email.lower())
+                self._abort_if_unique_id_mismatch(reason="wrong_account")
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates={"password": password},
+                )
 
         return self.async_show_form(
-            step_id="user",
-            data_schema=data_schema,
-            errors=errors
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("password"): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
+                }
+            ),
+            errors=errors,
         )
+
+    # -- Reconfiguration ----------------------------------------------------
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Let the user update email and/or password."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            email = user_input["email"]
+            password = user_input["password"]
+            try:
+                await self.hass.async_add_executor_job(_try_login, email, password)
+            except Exception:
+                _LOGGER.exception("Reconfigure authentication failed")
+                errors["base"] = "auth"
+            else:
+                await self.async_set_unique_id(email.lower())
+                self._abort_if_unique_id_mismatch(reason="wrong_account")
+                return self.async_update_reload_and_abort(
+                    self._get_reconfigure_entry(),
+                    data_updates={"email": email, "password": password},
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure", data_schema=USER_SCHEMA, errors=errors
+        )
+
+    # -- Options flow -------------------------------------------------------
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
-        return FellowAidenOptionsFlowHandler(config_entry)
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> FellowAidenOptionsFlowHandler:
+        return FellowAidenOptionsFlowHandler()
 
 
 class FellowAidenOptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle options flow if you want user to adjust settings after setup."""
+    """Handle options (polling interval)."""
 
-    def __init__(self, config_entry):
-        """Initialize."""
-        self._config_entry = config_entry
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        errors: dict[str, str] = {}
 
-    async def async_step_init(self, user_input=None):
-        """Manage the options."""
-        errors = {}
-        
         if user_input is not None:
-            # Validate update interval
-            update_interval_seconds = user_input.get("update_interval_seconds")
-            if update_interval_seconds < MIN_UPDATE_INTERVAL_SECONDS:
+            interval = user_input.get("update_interval_seconds")
+            if interval is not None and interval < MIN_UPDATE_INTERVAL_SECONDS:
                 errors["update_interval_seconds"] = "too_fast"
             else:
                 return self.async_create_entry(title="", data=user_input)
 
-        # Get current values or defaults
-        current_interval = self._config_entry.options.get(
+        current_interval = self.config_entry.options.get(
             "update_interval_seconds", DEFAULT_UPDATE_INTERVAL_MINUTES * 60
         )
 
-        data_schema = vol.Schema({
-            vol.Optional(
-                "update_interval_seconds",
-                default=current_interval,
-                description="Advanced: Update interval in seconds (minimum 30s, default 60s)"
-            ): vol.All(vol.Coerce(int), vol.Range(min=MIN_UPDATE_INTERVAL_SECONDS, max=300))
-        })
-
         return self.async_show_form(
             step_id="init",
-            data_schema=data_schema,
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        "update_interval_seconds",
+                        default=current_interval,
+                    ): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(min=MIN_UPDATE_INTERVAL_SECONDS, max=300),
+                    ),
+                }
+            ),
             errors=errors,
-            description_placeholders={
-                "current_interval": str(current_interval),
-                "min_interval": str(MIN_UPDATE_INTERVAL_SECONDS)
-            },
             last_step=True,
         )

--- a/custom_components/fellow/config_flow.py
+++ b/custom_components/fellow/config_flow.py
@@ -77,7 +77,8 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             password = user_input["password"]
-            assert self._reauth_email is not None
+            if self._reauth_email is None:
+                return self.async_abort(reason="unknown")
             try:
                 await self.hass.async_add_executor_job(
                     _try_login, self._reauth_email, password

--- a/custom_components/fellow/const.py
+++ b/custom_components/fellow/const.py
@@ -1,4 +1,15 @@
 """Constants for Fellow Aiden."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+
+    from .coordinator import FellowAidenDataUpdateCoordinator
+
+type FellowAidenConfigEntry = ConfigEntry[FellowAidenDataUpdateCoordinator]
+
 DOMAIN = "fellow"
 PLATFORMS = ["sensor", "select", "binary_sensor"]
 

--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -74,6 +74,9 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # If UpdateFailed was already raised, propagate it
             _LOGGER.exception("UpdateFailed exception during data update")
             raise
+        except ConfigEntryAuthFailed:
+            _LOGGER.warning("Authentication failed, triggering reauth flow")
+            raise
         except Exception as err:
             _LOGGER.exception("Unexpected error during data update: %s", err)
             raise UpdateFailed(f"Unexpected error: {err}") from err
@@ -156,7 +159,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             result = await self.hass.async_add_executor_job(self.api.create_profile, profile_data)
             _LOGGER.debug("Profile creation result: %s", result)
         except Exception as e:
-            _LOGGER.exception("Profile creation failed: %s", e)
+            _LOGGER.exception("Profile creation failed")
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
@@ -172,7 +175,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             _LOGGER.debug("Profile deletion result: %s", result)
         except Exception as e:
-            _LOGGER.exception("Profile deletion failed: %s", e)
+            _LOGGER.exception("Profile deletion failed")
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
@@ -188,7 +191,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             _LOGGER.debug("Schedule creation result: %s", result)
         except Exception as e:
-            _LOGGER.exception("Schedule creation failed: %s", e)
+            _LOGGER.exception("Schedule creation failed")
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
@@ -204,7 +207,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             _LOGGER.debug("Schedule deletion result: %s", result)
         except Exception as e:
-            _LOGGER.exception("Schedule deletion failed: %s", e)
+            _LOGGER.exception("Schedule deletion failed")
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
@@ -220,7 +223,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             _LOGGER.debug("Schedule toggle result: %s", result)
         except Exception as e:
-            _LOGGER.exception("Schedule toggle failed: %s", e)
+            _LOGGER.exception("Schedule toggle failed")
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()

--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .fellow_aiden import FellowAiden
@@ -103,7 +104,9 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.api._FellowAiden__device()  # <-- HACK: Accessing private method
             except Exception as auth_e:
                 _LOGGER.error("Re-authentication failed: %s", auth_e)
-                raise UpdateFailed(f"Error updating data: {auth_e}") from auth_e
+                raise ConfigEntryAuthFailed(
+                    f"Authentication failed: {auth_e}"
+                ) from auth_e
 
         brewer_name = self.api.get_display_name()
         profiles = self.api.get_profiles()

--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -128,10 +128,6 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 brewer_name,
             )
 
-        _LOGGER.debug("Fetched: brewer=%s, %d profiles, %d schedules",
-            brewer_name, len(profiles) if profiles else 0,
-            len(schedules) if schedules else 0)
-
         if not brewer_name or not device_config:
             _LOGGER.error("Incomplete data fetched from Fellow Aiden.")
             raise UpdateFailed("Incomplete data fetched from Fellow Aiden.")
@@ -146,7 +142,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         }
         _LOGGER.debug(
             "Returning data: %d profiles, %d schedules",
-            len(profiles), len(schedules) if schedules else 0,
+            len(profiles) if profiles else 0, len(schedules) if schedules else 0,
         )
         return result
 
@@ -160,7 +156,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             result = await self.hass.async_add_executor_job(self.api.create_profile, profile_data)
             _LOGGER.debug("Profile creation result: %s", result)
         except Exception as e:
-            _LOGGER.error("Profile creation failed: %s", e)
+            _LOGGER.exception("Profile creation failed: %s", e)
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
@@ -176,7 +172,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             _LOGGER.debug("Profile deletion result: %s", result)
         except Exception as e:
-            _LOGGER.error("Profile deletion failed: %s", e)
+            _LOGGER.exception("Profile deletion failed: %s", e)
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
@@ -192,7 +188,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             _LOGGER.debug("Schedule creation result: %s", result)
         except Exception as e:
-            _LOGGER.error("Schedule creation failed: %s", e)
+            _LOGGER.exception("Schedule creation failed: %s", e)
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
@@ -208,7 +204,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             _LOGGER.debug("Schedule deletion result: %s", result)
         except Exception as e:
-            _LOGGER.error("Schedule deletion failed: %s", e)
+            _LOGGER.exception("Schedule deletion failed: %s", e)
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
@@ -224,7 +220,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             _LOGGER.debug("Schedule toggle result: %s", result)
         except Exception as e:
-            _LOGGER.error("Schedule toggle failed: %s", e)
+            _LOGGER.exception("Schedule toggle failed: %s", e)
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()

--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -158,7 +158,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             result = await self.hass.async_add_executor_job(self.api.create_profile, profile_data)
             _LOGGER.debug("Profile creation result: %s", result)
-        except Exception as e:
+        except Exception:
             _LOGGER.exception("Profile creation failed")
             raise
         self._next_refresh_verbose = True
@@ -174,7 +174,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.api.delete_profile_by_id, profile_id
             )
             _LOGGER.debug("Profile deletion result: %s", result)
-        except Exception as e:
+        except Exception:
             _LOGGER.exception("Profile deletion failed")
             raise
         self._next_refresh_verbose = True
@@ -190,7 +190,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.api.create_schedule, schedule_data
             )
             _LOGGER.debug("Schedule creation result: %s", result)
-        except Exception as e:
+        except Exception:
             _LOGGER.exception("Schedule creation failed")
             raise
         self._next_refresh_verbose = True
@@ -206,7 +206,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.api.delete_schedule_by_id, schedule_id
             )
             _LOGGER.debug("Schedule deletion result: %s", result)
-        except Exception as e:
+        except Exception:
             _LOGGER.exception("Schedule deletion failed")
             raise
         self._next_refresh_verbose = True
@@ -222,7 +222,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.api.toggle_schedule, schedule_id, enabled
             )
             _LOGGER.debug("Schedule toggle result: %s", result)
-        except Exception as e:
+        except Exception:
             _LOGGER.exception("Schedule toggle failed")
             raise
         self._next_refresh_verbose = True

--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -115,19 +115,22 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         if verbose_logging:
             _LOGGER.info("=== Fellow Aiden API Response ===")
-            _LOGGER.info(f"Brewer name: {brewer_name}")
-            _LOGGER.info(f"Profiles ({len(profiles) if profiles else 0}): {profiles}")
-            _LOGGER.info(f"Device config: {device_config}")
-            _LOGGER.info(f"Schedules ({len(schedules) if schedules else 0}): {schedules}")
+            _LOGGER.info("Brewer name: %s", brewer_name)
+            _LOGGER.info("Profiles (%d): %s", len(profiles) if profiles else 0, profiles)
+            _LOGGER.info("Device config: %s", device_config)
+            _LOGGER.info("Schedules (%d): %s", len(schedules) if schedules else 0, schedules)
             _LOGGER.info("=== End API Response ===")
         else:
-            # Only log summary info during regular polling
-            _LOGGER.debug(f"Polled: {len(profiles) if profiles else 0} profiles, {len(schedules) if schedules else 0} schedules, device: {brewer_name}")
+            _LOGGER.debug(
+                "Polled: %d profiles, %d schedules, device: %s",
+                len(profiles) if profiles else 0,
+                len(schedules) if schedules else 0,
+                brewer_name,
+            )
 
-        _LOGGER.debug(f"Fetched brewer name: {brewer_name}")
-        _LOGGER.debug(f"Fetched profiles: {profiles}")
-        _LOGGER.debug(f"Fetched device config: {device_config}")
-        _LOGGER.debug(f"Fetched schedules: {schedules}")
+        _LOGGER.debug("Fetched: brewer=%s, %d profiles, %d schedules",
+            brewer_name, len(profiles) if profiles else 0,
+            len(schedules) if schedules else 0)
 
         if not brewer_name or not device_config:
             _LOGGER.error("Incomplete data fetched from Fellow Aiden.")
@@ -141,7 +144,10 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "device_config": device_config,
             "schedules": schedules,
         }
-        _LOGGER.debug(f"Returning data with {len(profiles)} profiles, {len(schedules) if schedules else 0} schedules, and device config keys: {list(device_config.keys()) if device_config else 'None'}")
+        _LOGGER.debug(
+            "Returning data: %d profiles, %d schedules",
+            len(profiles), len(schedules) if schedules else 0,
+        )
         return result
 
 
@@ -154,7 +160,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             result = await self.hass.async_add_executor_job(self.api.create_profile, profile_data)
             _LOGGER.debug("Profile creation result: %s", result)
         except Exception as e:
-            _LOGGER.error(f"Profile creation failed: {e}")
+            _LOGGER.error("Profile creation failed: %s", e)
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
@@ -170,7 +176,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             _LOGGER.debug("Profile deletion result: %s", result)
         except Exception as e:
-            _LOGGER.error(f"Profile deletion failed: {e}")
+            _LOGGER.error("Profile deletion failed: %s", e)
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
@@ -186,7 +192,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             _LOGGER.debug("Schedule creation result: %s", result)
         except Exception as e:
-            _LOGGER.error(f"Schedule creation failed: {e}")
+            _LOGGER.error("Schedule creation failed: %s", e)
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
@@ -202,7 +208,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             _LOGGER.debug("Schedule deletion result: %s", result)
         except Exception as e:
-            _LOGGER.error(f"Schedule deletion failed: {e}")
+            _LOGGER.error("Schedule deletion failed: %s", e)
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()
@@ -218,7 +224,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             _LOGGER.debug("Schedule toggle result: %s", result)
         except Exception as e:
-            _LOGGER.error(f"Schedule toggle failed: {e}")
+            _LOGGER.error("Schedule toggle failed: %s", e)
             raise
         self._next_refresh_verbose = True
         await self.async_request_refresh()

--- a/custom_components/fellow/diagnostics.py
+++ b/custom_components/fellow/diagnostics.py
@@ -1,0 +1,42 @@
+"""Diagnostics for Fellow Aiden."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+
+from .const import FellowAidenConfigEntry
+
+TO_REDACT_CONFIG = {"email", "password"}
+TO_REDACT_DEVICE = {
+    "wifiMacAddress",
+    "btMacAddress",
+    "wifiSSID",
+    "localIpAddress",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: FellowAidenConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = entry.runtime_data
+    data = coordinator.data or {}
+
+    return {
+        "entry_data": async_redact_data(dict(entry.data), TO_REDACT_CONFIG),
+        "options": dict(entry.options),
+        "coordinator": {
+            "last_update_success": coordinator.last_update_success,
+            "update_interval_seconds": coordinator.update_interval.total_seconds()
+            if coordinator.update_interval
+            else None,
+        },
+        "device_config": async_redact_data(
+            data.get("device_config", {}), TO_REDACT_DEVICE
+        ),
+        "profiles_count": len(data.get("profiles", [])),
+        "schedules_count": len(data.get("schedules", [])),
+        "brewer_name": data.get("brewer_name"),
+    }

--- a/custom_components/fellow/icons.json
+++ b/custom_components/fellow/icons.json
@@ -1,0 +1,46 @@
+{
+  "entity": {
+    "sensor": {
+      "chime_volume": { "default": "mdi:volume-high" },
+      "total_brews": { "default": "mdi:counter" },
+      "total_water_volume": { "default": "mdi:cup-water" },
+      "last_brew_volume": { "default": "mdi:coffee-outline" },
+      "average_water_per_brew": { "default": "mdi:cup-water" },
+      "last_brew_start_time": { "default": "mdi:clock-start" },
+      "last_brew_end_time": { "default": "mdi:clock-end" },
+      "last_brew_duration": { "default": "mdi:timer-outline" },
+      "average_time_between_brews": { "default": "mdi:clock-outline" },
+      "last_brew_time": { "default": "mdi:coffee-outline" },
+      "total_water_today": { "default": "mdi:water" },
+      "total_water_this_week": { "default": "mdi:water" },
+      "total_water_this_month": { "default": "mdi:water" },
+      "average_brew_duration": { "default": "mdi:timer" },
+      "most_popular_profile": { "default": "mdi:star" },
+      "current_profile": { "default": "mdi:coffee" },
+      "basket": { "default": "mdi:basket" }
+    },
+    "binary_sensor": {
+      "brewing": { "default": "mdi:coffee-maker" },
+      "carafe_inserted": { "default": "mdi:coffee-maker-outline" },
+      "heater": { "default": "mdi:fire" },
+      "lid": { "default": "mdi:door" },
+      "missing_water": { "default": "mdi:water-off" }
+    },
+    "select": {
+      "profiles": { "default": "mdi:format-list-bulleted" }
+    }
+  },
+  "services": {
+    "create_profile": "mdi:plus-circle",
+    "delete_profile": "mdi:delete",
+    "list_profiles": "mdi:format-list-bulleted",
+    "get_profile_details": "mdi:information",
+    "create_schedule": "mdi:calendar-plus",
+    "delete_schedule": "mdi:calendar-remove",
+    "toggle_schedule": "mdi:calendar-check",
+    "list_schedules": "mdi:calendar-text",
+    "reset_water_tracking": "mdi:water-sync",
+    "debug_water_usage": "mdi:bug",
+    "refresh_and_log_data": "mdi:refresh"
+  }
+}

--- a/custom_components/fellow/select.py
+++ b/custom_components/fellow/select.py
@@ -27,9 +27,9 @@ async def async_setup_entry(
 class FellowAidenProfilesSelect(FellowAidenBaseEntity, SelectEntity):
     """Dropdown showing available brew profiles.
 
-    Selecting a profile from the UI is not supported by the Fellow API,
-    so async_select_option logs a warning and does nothing. Use the
-    schedule or device controls to brew with a specific profile.
+    Selecting a profile from the UI is not supported by the Fellow API;
+    async_select_option raises HomeAssistantError. Use the schedule or
+    device controls to brew with a specific profile.
     """
 
     def __init__(self, coordinator: FellowAidenDataUpdateCoordinator, entry: ConfigEntry) -> None:

--- a/custom_components/fellow/select.py
+++ b/custom_components/fellow/select.py
@@ -1,18 +1,15 @@
 """Select entity to list brew profiles from Fellow Aiden."""
 from __future__ import annotations
 
-import logging
-
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import FellowAidenConfigEntry
+from .const import DOMAIN, FellowAidenConfigEntry
 from .coordinator import FellowAidenDataUpdateCoordinator
 from .base_entity import FellowAidenBaseEntity
-
-_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
@@ -77,8 +74,8 @@ class FellowAidenProfilesSelect(FellowAidenBaseEntity, SelectEntity):
         return data["profiles"][0].get("title", "Profile 1")
 
     async def async_select_option(self, option: str) -> None:
-        """No-op. The Fellow API doesn't support switching profiles remotely."""
-        _LOGGER.warning(
-            "Profile selection for '%s' ignored; the Fellow API doesn't support remote profile switching",
-            option,
+        """Raise error — the Fellow API doesn't support switching profiles remotely."""
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="profile_selection_not_supported",
         )

--- a/custom_components/fellow/select.py
+++ b/custom_components/fellow/select.py
@@ -78,7 +78,7 @@ class FellowAidenProfilesSelect(FellowAidenBaseEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """No-op. The Fellow API doesn't support switching profiles remotely."""
-        _LOGGER.info(
+        _LOGGER.warning(
             "Profile selection for '%s' ignored; the Fellow API doesn't support remote profile switching",
             option,
         )

--- a/custom_components/fellow/select.py
+++ b/custom_components/fellow/select.py
@@ -14,6 +14,8 @@ from .base_entity import FellowAidenBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/fellow/select.py
+++ b/custom_components/fellow/select.py
@@ -65,7 +65,7 @@ class FellowAidenProfilesSelect(FellowAidenBaseEntity, SelectEntity):
                     None,
                 )
                 if selected_profile:
-                    return selected_profile["title"]
+                    return selected_profile.get("title", "Selected Profile")
 
         default_profile = next(
             (p for p in data["profiles"] if p.get("isDefaultProfile")),

--- a/custom_components/fellow/select.py
+++ b/custom_components/fellow/select.py
@@ -9,18 +9,18 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, FellowAidenConfigEntry
 from .coordinator import FellowAidenDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant, 
-    entry: ConfigEntry, 
+    entry: FellowAidenConfigEntry, 
     async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up select entity listing all brew profiles."""
-    coordinator: FellowAidenDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     async_add_entities([FellowAidenProfilesSelect(coordinator, entry)], update_before_add=True)
 
 

--- a/custom_components/fellow/sensor.py
+++ b/custom_components/fellow/sensor.py
@@ -13,6 +13,8 @@ from .base_entity import FellowAidenBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 # Standard sensors: (api_key, translation_key, unit, icon)
 STANDARD_SENSORS = [
     ("chimeVolume", "chime_volume", None, "mdi:volume-high"),

--- a/custom_components/fellow/sensor.py
+++ b/custom_components/fellow/sensor.py
@@ -375,7 +375,7 @@ class AidenTotalWaterTodaySensor(FellowAidenBaseEntity, SensorEntity):
         """Return total water used today using historical data."""
         # IMPORTANT: Only use historical tracking data, never fallback to device totals
         water_usage = self.coordinator.history_manager.get_water_usage_for_period(1)
-        _LOGGER.debug(f"Water usage today from history: {water_usage}L")
+        _LOGGER.debug("Water usage today from history: %s L", water_usage)
         
         # Ensure we never accidentally return device lifetime totals
         if water_usage is None or water_usage < 0:
@@ -416,7 +416,7 @@ class AidenTotalWaterWeekSensor(FellowAidenBaseEntity, SensorEntity):
         """Return total water used this week using historical data."""
         # IMPORTANT: Only use historical tracking data, never fallback to device totals
         water_usage = self.coordinator.history_manager.get_water_usage_for_period(7)
-        _LOGGER.debug(f"Water usage this week from history: {water_usage}L")
+        _LOGGER.debug("Water usage this week from history: %s L", water_usage)
         
         # Ensure we never accidentally return device lifetime totals
         if water_usage is None or water_usage < 0:
@@ -459,7 +459,7 @@ class AidenTotalWaterMonthSensor(FellowAidenBaseEntity, SensorEntity):
         """Return total water used this month using historical data."""
         # IMPORTANT: Only use historical tracking data, never fallback to device totals
         water_usage = self.coordinator.history_manager.get_water_usage_for_period(30)
-        _LOGGER.debug(f"Water usage this month from history: {water_usage}L")
+        _LOGGER.debug("Water usage this month from history: %s L", water_usage)
         
         # Ensure we never accidentally return device lifetime totals
         if water_usage is None or water_usage < 0:
@@ -624,7 +624,11 @@ class AidenCurrentProfileSensor(FellowAidenBaseEntity, SensorEntity):
         """Return the current profile name."""
         _LOGGER.debug("Getting current profile value")
         data = self.coordinator.data
-        _LOGGER.debug(f"Data available: {data is not None}, profiles count: {len(data.get('profiles', [])) if data else 0}")
+        _LOGGER.debug(
+            "Profile data available: %s, profiles: %d",
+            data is not None,
+            len(data.get("profiles", [])) if data else 0,
+        )
 
         if data and "profiles" in data and data["profiles"]:
             # Method 1: Check against the "ibSelectedProfileId" field, if set.
@@ -657,7 +661,11 @@ class AidenCurrentProfileSensor(FellowAidenBaseEntity, SensorEntity):
             if profiles_with_last_used:
                 profiles_with_last_used.sort(key=lambda x: x[1], reverse=True)
                 most_recent_profile = profiles_with_last_used[0][0]
-                _LOGGER.debug(f"Found most recent profile: {most_recent_profile.get('title')} (lastUsedTime: {profiles_with_last_used[0][1]})")
+                _LOGGER.debug(
+                    "Most recent profile: %s (lastUsedTime: %s)",
+                    most_recent_profile.get("title"),
+                    profiles_with_last_used[0][1],
+                )
                 self.detection_method = "Recent Profile"
                 self.confidence = "very_high"
                 return most_recent_profile.get("title", "Recent Profile")
@@ -669,7 +677,7 @@ class AidenCurrentProfileSensor(FellowAidenBaseEntity, SensorEntity):
                 None
             )
             if default_profile:
-                _LOGGER.debug(f"Using default profile: {default_profile.get('title')}")
+                _LOGGER.debug("Using default profile: %s", default_profile.get("title"))
                 self.detection_method = "Default Profile"
                 self.confidence = "medium"
                 return default_profile.get("title", "Default Profile")
@@ -677,7 +685,7 @@ class AidenCurrentProfileSensor(FellowAidenBaseEntity, SensorEntity):
         # Method 4: Use most popular profile from history
         most_popular = self.coordinator.history_manager.get_most_popular_profile()
         if most_popular:
-            _LOGGER.debug(f"Using most popular from history: {most_popular}")
+            _LOGGER.debug("Using most popular from history: %s", most_popular)
             self.detection_method = "historical_usage"
             self.confidence = "low_medium"
             return most_popular

--- a/custom_components/fellow/sensor.py
+++ b/custom_components/fellow/sensor.py
@@ -21,18 +21,18 @@ _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
-# Standard sensors: (api_key, translation_key, unit, icon, device_class, state_class, entity_category, disabled_default)
+# Standard sensors: (api_key, translation_key, unit, device_class, state_class, entity_category, disabled_default)
 STANDARD_SENSORS = [
-    ("chimeVolume", "chime_volume", None, "mdi:volume-high", None, None, EntityCategory.DIAGNOSTIC, True),
-    ("totalBrewingCycles", "total_brews", None, "mdi:counter", None, SensorStateClass.TOTAL_INCREASING, None, False),
-    ("totalWaterVolumeL", "total_water_volume", UnitOfVolume.LITERS, "mdi:cup-water", SensorDeviceClass.VOLUME, SensorStateClass.TOTAL_INCREASING, None, False),
-    ("brewingWaterVolumeMl", "last_brew_volume", UnitOfVolume.MILLILITERS, "mdi:coffee-outline", SensorDeviceClass.VOLUME, None, None, False),
+    ("chimeVolume", "chime_volume", None, None, None, EntityCategory.DIAGNOSTIC, True),
+    ("totalBrewingCycles", "total_brews", None, None, SensorStateClass.TOTAL_INCREASING, None, False),
+    ("totalWaterVolumeL", "total_water_volume", UnitOfVolume.LITERS, SensorDeviceClass.VOLUME, SensorStateClass.TOTAL_INCREASING, None, False),
+    ("brewingWaterVolumeMl", "last_brew_volume", UnitOfVolume.MILLILITERS, SensorDeviceClass.VOLUME, None, None, False),
 ]
 
-# Brew time sensors: (api_key, translation_key, icon)
+# Brew time sensors: (api_key, translation_key)
 BREW_TIME_SENSORS = [
-    ("brewStartTime", "last_brew_start_time", "mdi:clock-start"),
-    ("brewEndTime", "last_brew_end_time", "mdi:clock-end"),
+    ("brewStartTime", "last_brew_start_time"),
+    ("brewEndTime", "last_brew_end_time"),
 ]
 
 async def async_setup_entry(
@@ -51,7 +51,7 @@ async def async_setup_entry(
     entities: list[SensorEntity] = []
 
     # Standard sensors from device config
-    for key, translation_key, unit, icon, device_class, state_class, category, disabled in STANDARD_SENSORS:
+    for key, translation_key, unit, device_class, state_class, category, disabled in STANDARD_SENSORS:
         entities.append(
             AidenSensor(
                 coordinator=coordinator,
@@ -59,7 +59,6 @@ async def async_setup_entry(
                 key=key,
                 translation_key=translation_key,
                 unit=unit,
-                icon=icon,
                 device_class=device_class,
                 state_class=state_class,
                 entity_category=category,
@@ -76,14 +75,13 @@ async def async_setup_entry(
     )
 
     # Brew time sensors
-    for key, translation_key, icon in BREW_TIME_SENSORS:
+    for key, translation_key in BREW_TIME_SENSORS:
         entities.append(
             AidenBrewTimeSensor(
                 coordinator=coordinator,
                 entry=entry,
                 key=key,
                 translation_key=translation_key,
-                icon=icon
             )
         )
 
@@ -123,7 +121,6 @@ class AidenSensor(FellowAidenBaseEntity, SensorEntity):
         key: str,
         translation_key: str,
         unit: str | None,
-        icon: str | None,
         device_class: SensorDeviceClass | None = None,
         state_class: SensorStateClass | None = None,
         entity_category: EntityCategory | None = None,
@@ -135,7 +132,6 @@ class AidenSensor(FellowAidenBaseEntity, SensorEntity):
         self._attr_translation_key = translation_key
         self._attr_unique_id = f"{entry.entry_id}-{key}"
         self._attr_native_unit_of_measurement = unit
-        self._attr_icon = icon
         self._attr_device_class = device_class
         self._attr_state_class = state_class
         self._attr_entity_category = entity_category
@@ -166,7 +162,6 @@ class AidenAverageWaterPerBrewSensor(FellowAidenBaseEntity, SensorEntity):
         self._entry_id = entry.entry_id
         self._attr_translation_key = "average_water_per_brew"
         self._attr_unique_id = f"{entry.entry_id}-avg_water_per_brew"
-        self._attr_icon = "mdi:cup-water"
         self._attr_native_unit_of_measurement = UnitOfVolume.MILLILITERS
         self._attr_device_class = SensorDeviceClass.VOLUME
 
@@ -195,14 +190,12 @@ class AidenBrewTimeSensor(FellowAidenBaseEntity, SensorEntity):
         entry: ConfigEntry,
         key: str,
         translation_key: str,
-        icon: str,
     ) -> None:
         super().__init__(coordinator)
         self._entry_id = entry.entry_id
         self._key = key
         self._attr_translation_key = translation_key
         self._attr_unique_id = f"{entry.entry_id}-{key}"
-        self._attr_icon = icon
 
     @property
     def native_value(self) -> str | None:
@@ -246,7 +239,6 @@ class AidenLastBrewDurationSensor(FellowAidenBaseEntity, SensorEntity):
         self._entry_id = entry.entry_id
         self._attr_translation_key = "last_brew_duration"
         self._attr_unique_id = f"{entry.entry_id}-last_brew_duration"
-        self._attr_icon = "mdi:timer-outline"
         self._attr_native_unit_of_measurement = UnitOfTime.SECONDS
         self._attr_device_class = SensorDeviceClass.DURATION
 
@@ -296,7 +288,6 @@ class AidenAverageTimeBetweenBrewsSensor(FellowAidenBaseEntity, SensorEntity):
         self._entry_id = entry.entry_id
         self._attr_translation_key = "average_time_between_brews"
         self._attr_unique_id = f"{entry.entry_id}-avg_time_between_brews"
-        self._attr_icon = "mdi:clock-outline"
         self._attr_native_unit_of_measurement = UnitOfTime.HOURS
         self._attr_device_class = SensorDeviceClass.DURATION
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -330,7 +321,6 @@ class AidenLastBrewTimeSensor(FellowAidenBaseEntity, SensorEntity):
         self._entry_id = entry.entry_id
         self._attr_translation_key = "last_brew_time"
         self._attr_unique_id = f"{entry.entry_id}-last_brew_time"
-        self._attr_icon = "mdi:coffee-outline"
         self._attr_device_class = "timestamp"
 
     @property
@@ -376,7 +366,6 @@ class AidenTotalWaterTodaySensor(FellowAidenBaseEntity, SensorEntity):
         self._entry_id = entry.entry_id
         self._attr_translation_key = "total_water_today"
         self._attr_unique_id = f"{entry.entry_id}-total_water_today"
-        self._attr_icon = "mdi:water"
         self._attr_native_unit_of_measurement = UnitOfVolume.LITERS
         self._attr_device_class = SensorDeviceClass.VOLUME
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
@@ -418,7 +407,6 @@ class AidenTotalWaterWeekSensor(FellowAidenBaseEntity, SensorEntity):
         self._entry_id = entry.entry_id
         self._attr_translation_key = "total_water_this_week"
         self._attr_unique_id = f"{entry.entry_id}-total_water_week"
-        self._attr_icon = "mdi:water"
         self._attr_native_unit_of_measurement = UnitOfVolume.LITERS
         self._attr_device_class = SensorDeviceClass.VOLUME
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
@@ -462,7 +450,6 @@ class AidenTotalWaterMonthSensor(FellowAidenBaseEntity, SensorEntity):
         self._entry_id = entry.entry_id
         self._attr_translation_key = "total_water_this_month"
         self._attr_unique_id = f"{entry.entry_id}-total_water_month"
-        self._attr_icon = "mdi:water"
         self._attr_native_unit_of_measurement = UnitOfVolume.LITERS
         self._attr_device_class = SensorDeviceClass.VOLUME
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
@@ -506,7 +493,6 @@ class AidenAverageBrewDurationSensor(FellowAidenBaseEntity, SensorEntity):
         self._entry_id = entry.entry_id
         self._attr_translation_key = "average_brew_duration"
         self._attr_unique_id = f"{entry.entry_id}-avg_brew_duration"
-        self._attr_icon = "mdi:timer"
         self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
         self._attr_device_class = SensorDeviceClass.DURATION
 
@@ -567,7 +553,6 @@ class AidenMostPopularProfileSensor(FellowAidenBaseEntity, SensorEntity):
         self._entry_id = entry.entry_id
         self._attr_translation_key = "most_popular_profile"
         self._attr_unique_id = f"{entry.entry_id}-most_popular_profile"
-        self._attr_icon = "mdi:star"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_entity_registry_enabled_default = False
 
@@ -631,7 +616,6 @@ class AidenCurrentProfileSensor(FellowAidenBaseEntity, SensorEntity):
         self._entry_id = entry.entry_id
         self._attr_translation_key = "current_profile"
         self._attr_unique_id = f"{entry.entry_id}-current_profile"
-        self._attr_icon = "mdi:coffee"
         self.detection_method = "unknown"
         self.confidence = "low"
 
@@ -770,7 +754,6 @@ class AidenBasketSensor(FellowAidenBaseEntity, SensorEntity):
         self._entry_id = entry.entry_id
         self._attr_translation_key = "basket"
         self._attr_unique_id = f"{entry.entry_id}-basket"
-        self._attr_icon = "mdi:basket"
 
     @property
     def native_value(self) -> str:

--- a/custom_components/fellow/sensor.py
+++ b/custom_components/fellow/sensor.py
@@ -373,7 +373,7 @@ class AidenTotalWaterTodaySensor(FellowAidenBaseEntity, SensorEntity):
         self._attr_unique_id = f"{entry.entry_id}-total_water_today"
         self._attr_native_unit_of_measurement = UnitOfVolume.LITERS
         self._attr_device_class = SensorDeviceClass.VOLUME
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_state_class = SensorStateClass.TOTAL
 
     @property
     def native_value(self) -> float | None:
@@ -414,7 +414,7 @@ class AidenTotalWaterWeekSensor(FellowAidenBaseEntity, SensorEntity):
         self._attr_unique_id = f"{entry.entry_id}-total_water_week"
         self._attr_native_unit_of_measurement = UnitOfVolume.LITERS
         self._attr_device_class = SensorDeviceClass.VOLUME
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_state_class = SensorStateClass.TOTAL
 
     @property
     def native_value(self) -> float | None:
@@ -457,7 +457,7 @@ class AidenTotalWaterMonthSensor(FellowAidenBaseEntity, SensorEntity):
         self._attr_unique_id = f"{entry.entry_id}-total_water_month"
         self._attr_native_unit_of_measurement = UnitOfVolume.LITERS
         self._attr_device_class = SensorDeviceClass.VOLUME
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_state_class = SensorStateClass.TOTAL
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/fellow/sensor.py
+++ b/custom_components/fellow/sensor.py
@@ -7,7 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, TIMESTAMP_2024_01_01, MIN_VALID_YEAR, MIN_HISTORICAL_DATA_FOR_ACCURACY
+from .const import DOMAIN, TIMESTAMP_2024_01_01, MIN_VALID_YEAR, MIN_HISTORICAL_DATA_FOR_ACCURACY, FellowAidenConfigEntry
 from .coordinator import FellowAidenDataUpdateCoordinator
 from .base_entity import FellowAidenBaseEntity
 
@@ -31,12 +31,12 @@ BREW_TIME_SENSORS = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: FellowAidenConfigEntry,
     async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up sensors for the Fellow Aiden integration."""
     _LOGGER.debug("Setting up sensors for entry %s", entry.entry_id)
-    coordinator: FellowAidenDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     _LOGGER.debug("Coordinator data available: %s", coordinator.data is not None)
     if coordinator.data:

--- a/custom_components/fellow/sensor.py
+++ b/custom_components/fellow/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import UnitOfTime, UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, TIMESTAMP_2024_01_01, MIN_VALID_YEAR, MIN_HISTORICAL_DATA_FOR_ACCURACY, FellowAidenConfigEntry
 from .coordinator import FellowAidenDataUpdateCoordinator
@@ -204,8 +205,6 @@ class AidenBrewTimeSensor(FellowAidenBaseEntity, SensorEntity):
     @property
     def native_value(self) -> datetime | None:
         """Return the brew time as a timezone-aware datetime."""
-        from homeassistant.util import dt as dt_util
-
         data = self.coordinator.data or {}
         device_config = data.get("device_config", {})
         timestamp_str = device_config.get(self._key)
@@ -328,8 +327,6 @@ class AidenLastBrewTimeSensor(FellowAidenBaseEntity, SensorEntity):
     @property
     def native_value(self) -> datetime | None:
         """Return the last brew completion time using historical data."""
-        from homeassistant.util import dt as dt_util
-        
         # Try historical data first, fallback to device data
         historical_time = self.coordinator.history_manager.get_last_brew_time()
         if historical_time:
@@ -723,7 +720,6 @@ class AidenCurrentProfileSensor(FellowAidenBaseEntity, SensorEntity):
                         continue
 
             if profiles_with_last_used:
-                from homeassistant.util import dt as dt_util
                 profiles_with_last_used.sort(key=lambda x: x[1], reverse=True)
                 most_recent_timestamp = profiles_with_last_used[0][1]
                 try:

--- a/custom_components/fellow/sensor.py
+++ b/custom_components/fellow/sensor.py
@@ -140,7 +140,10 @@ class AidenSensor(FellowAidenBaseEntity, SensorEntity):
     @property
     def native_value(self) -> Any:
         """Retrieve and process the sensor's value."""
-        device_config = self.coordinator.data.get("device_config", {})
+        data = self.coordinator.data
+        if not data:
+            return None
+        device_config = data.get("device_config", {})
         value = device_config.get(self._key)
 
         # Apply unit conversion for water volume if applicable
@@ -245,7 +248,10 @@ class AidenLastBrewDurationSensor(FellowAidenBaseEntity, SensorEntity):
     @property
     def native_value(self) -> int | None:
         """Compute and return the duration of the last brew cycle."""
-        device_config = self.coordinator.data.get("device_config", {})
+        data = self.coordinator.data
+        if not data:
+            return None
+        device_config = data.get("device_config", {})
         start_time_str = device_config.get("brewStartTime")
         end_time_str = device_config.get("brewEndTime")
 
@@ -337,7 +343,10 @@ class AidenLastBrewTimeSensor(FellowAidenBaseEntity, SensorEntity):
             return historical_time
             
         # Fallback to device data
-        device_config = self.coordinator.data.get("device_config", {})
+        data = self.coordinator.data
+        if not data:
+            return None
+        device_config = data.get("device_config", {})
         end_time_str = device_config.get("brewEndTime")
 
         if not end_time_str or end_time_str == "0":
@@ -368,7 +377,7 @@ class AidenTotalWaterTodaySensor(FellowAidenBaseEntity, SensorEntity):
         self._attr_unique_id = f"{entry.entry_id}-total_water_today"
         self._attr_native_unit_of_measurement = UnitOfVolume.LITERS
         self._attr_device_class = SensorDeviceClass.VOLUME
-        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def native_value(self) -> float | None:
@@ -409,7 +418,7 @@ class AidenTotalWaterWeekSensor(FellowAidenBaseEntity, SensorEntity):
         self._attr_unique_id = f"{entry.entry_id}-total_water_week"
         self._attr_native_unit_of_measurement = UnitOfVolume.LITERS
         self._attr_device_class = SensorDeviceClass.VOLUME
-        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def native_value(self) -> float | None:
@@ -452,7 +461,7 @@ class AidenTotalWaterMonthSensor(FellowAidenBaseEntity, SensorEntity):
         self._attr_unique_id = f"{entry.entry_id}-total_water_month"
         self._attr_native_unit_of_measurement = UnitOfVolume.LITERS
         self._attr_device_class = SensorDeviceClass.VOLUME
-        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def native_value(self) -> float | None:
@@ -504,7 +513,10 @@ class AidenAverageBrewDurationSensor(FellowAidenBaseEntity, SensorEntity):
             return historical_avg
             
         # Fallback to last brew duration if no historical data
-        device_config = self.coordinator.data.get("device_config", {})
+        data = self.coordinator.data
+        if not data:
+            return None
+        device_config = data.get("device_config", {})
         start_time_str = device_config.get("brewStartTime")
         end_time_str = device_config.get("brewEndTime")
 

--- a/custom_components/fellow/services.yaml
+++ b/custom_components/fellow/services.yaml
@@ -2,7 +2,7 @@ create_profile:
   name: "Create Brew Profile"
   description: "Create a new brew profile on the Fellow Aiden device."
   fields:
-    profileType:
+    profile_type:
       name: "Profile Type"
       description: "Numeric profile type"
       required: false
@@ -31,14 +31,14 @@ create_profile:
           max: 20
           step: 0.5
           mode: box
-    bloomEnabled:
+    bloom_enabled:
       name: "Bloom Enabled"
       description: "Should the bloom phase be used?"
       required: true
       example: true
       selector:
         boolean:
-    bloomRatio:
+    bloom_ratio:
       name: "Bloom Ratio"
       description: "Amount of water used in bloom relative to coffee weight (1.0–3.0)."
       required: true
@@ -49,7 +49,7 @@ create_profile:
           max: 3
           step: 0.5
           mode: box
-    bloomDuration:
+    bloom_duration:
       name: "Bloom Duration (seconds)"
       description: "Duration of bloom phase, 1–120 seconds."
       required: true
@@ -60,7 +60,7 @@ create_profile:
           max: 120
           step: 1
           mode: box
-    bloomTemperature:
+    bloom_temperature:
       name: "Bloom Temperature (°C)"
       description: "Temperature for bloom phase, 50–99°C."
       required: true
@@ -72,14 +72,14 @@ create_profile:
           step: 1
           unit_of_measurement: "°C"
           mode: box
-    ssPulsesEnabled:
+    ss_pulses_enabled:
       name: "Single Serve Pulses Enabled"
       description: "Enable pulses for Single Serve brewing?"
       required: true
       example: true
       selector:
         boolean:
-    ssPulsesNumber:
+    ss_pulses_number:
       name: "Single Serve Pulses Number"
       description: "How many pulses for Single Serve brewing? (1–10)."
       required: true
@@ -90,7 +90,7 @@ create_profile:
           max: 10
           step: 1
           mode: box
-    ssPulsesInterval:
+    ss_pulses_interval:
       name: "Single Serve Pulses Interval (seconds)"
       description: "Time between Single Serve pulses, 5–60."
       required: true
@@ -101,21 +101,21 @@ create_profile:
           max: 60
           step: 1
           mode: box
-    ssPulseTemperatures:
+    ss_pulse_temperatures:
       name: "Single Serve Pulse Temperatures (°C)"
       description: "Temperatures for each Single Serve pulse. Accepts comma-separated integers or JSON array (e.g., 96,97,98 or [96,97,98]). Values in °C (50–99)."
       required: true
       example: "96,97,98"
       selector:
         text:
-    batchPulsesEnabled:
+    batch_pulses_enabled:
       name: "Batch Pulses Enabled"
       description: "Enable batch pulses?"
       required: true
       example: true
       selector:
         boolean:
-    batchPulsesNumber:
+    batch_pulses_number:
       name: "Batch Pulses Number"
       description: "Number of batch pulses (1–10)."
       required: true
@@ -126,7 +126,7 @@ create_profile:
           max: 10
           step: 1
           mode: box
-    batchPulsesInterval:
+    batch_pulses_interval:
       name: "Batch Pulses Interval (seconds)"
       description: "Time between batch pulses, 5–60."
       required: true
@@ -137,7 +137,7 @@ create_profile:
           max: 60
           step: 1
           mode: box
-    batchPulseTemperatures:
+    batch_pulse_temperatures:
       name: "Batch Pulse Temperatures (°C)"
       description: "A list of temperatures for each batch pulse (e.g. `[96, 97]`). Values in °C (50–99)."
       required: true
@@ -217,7 +217,7 @@ create_schedule:
       example: "07:30:00"
       selector:
         time:
-    amountOfWater:
+    amount_of_water:
       name: "Water Amount (mL)"
       description: "Amount of water to use for brewing (150-1500 mL)."
       required: true
@@ -229,16 +229,16 @@ create_schedule:
           step: 1
           unit_of_measurement: "mL"
           mode: box
-    profileName:
+    profile_name:
       name: "Profile Name"
-      description: "Name of the brew profile to use. Either profileName or profileId must be provided (profileName takes precedence). Find names in the 'Fellow Aiden Profiles' dropdown."
+      description: "Name of the brew profile to use. Either profile_name or profile_id must be provided (profile_name takes precedence). Find names in the 'Fellow Aiden Profiles' dropdown."
       required: false
       example: "My Morning Coffee"
       selector:
         text:
-    profileId:
+    profile_id:
       name: "Profile ID (Alternative)"
-      description: "ID of the brew profile to use (e.g. 'p1'). Either profileName or profileId must be provided (profileName takes precedence)."
+      description: "ID of the brew profile to use (e.g. 'p1'). Either profile_name or profile_id must be provided (profile_name takes precedence)."
       required: false
       example: "p1"
       selector:

--- a/custom_components/fellow/strings.json
+++ b/custom_components/fellow/strings.json
@@ -101,7 +101,7 @@
       "name": "Create brew profile",
       "description": "Create a new brew profile on the Fellow Aiden.",
       "fields": {
-        "profile_type": {
+        "profileType": {
           "name": "Profile type",
           "description": "Numeric profile type."
         },
@@ -113,51 +113,51 @@
           "name": "Brew ratio",
           "description": "Coffee-to-water ratio (14-20 in 0.5 steps)."
         },
-        "bloom_enabled": {
+        "bloomEnabled": {
           "name": "Bloom enabled",
           "description": "Whether to use a bloom phase."
         },
-        "bloom_ratio": {
+        "bloomRatio": {
           "name": "Bloom ratio",
           "description": "Water used in bloom relative to coffee weight (1.0-3.0)."
         },
-        "bloom_duration": {
+        "bloomDuration": {
           "name": "Bloom duration",
           "description": "Bloom phase duration in seconds (1-120)."
         },
-        "bloom_temperature": {
+        "bloomTemperature": {
           "name": "Bloom temperature",
           "description": "Bloom phase temperature in Celsius (50-99)."
         },
-        "ss_pulses_enabled": {
+        "ssPulsesEnabled": {
           "name": "Single serve pulses enabled",
           "description": "Enable pulses for single serve brewing."
         },
-        "ss_pulses_number": {
+        "ssPulsesNumber": {
           "name": "Single serve pulse count",
           "description": "Number of single serve pulses (1-10)."
         },
-        "ss_pulses_interval": {
+        "ssPulsesInterval": {
           "name": "Single serve pulse interval",
           "description": "Seconds between single serve pulses (5-60)."
         },
-        "ss_pulse_temperatures": {
+        "ssPulseTemperatures": {
           "name": "Single serve pulse temperatures",
           "description": "Temperature list for each single serve pulse, e.g. [96, 97, 98]."
         },
-        "batch_pulses_enabled": {
+        "batchPulsesEnabled": {
           "name": "Batch pulses enabled",
           "description": "Enable batch brewing pulses."
         },
-        "batch_pulses_number": {
+        "batchPulsesNumber": {
           "name": "Batch pulse count",
           "description": "Number of batch pulses (1-10)."
         },
-        "batch_pulses_interval": {
+        "batchPulsesInterval": {
           "name": "Batch pulse interval",
           "description": "Seconds between batch pulses (5-60)."
         },
-        "batch_pulse_temperatures": {
+        "batchPulseTemperatures": {
           "name": "Batch pulse temperatures",
           "description": "Temperature list for each batch pulse, e.g. [96, 97]."
         }
@@ -252,7 +252,7 @@
       "message": "No profiles available."
     },
     "provide_profile_id_or_name": {
-      "message": "Provide profile_name or profile_id."
+      "message": "Provide a profile name or profile ID."
     },
     "provide_schedule_profile": {
       "message": "Provide a profile name or profile ID."

--- a/custom_components/fellow/strings.json
+++ b/custom_components/fellow/strings.json
@@ -283,6 +283,9 @@
     },
     "reset_water_failed": {
       "message": "Failed to reset water tracking: {error}"
+    },
+    "profile_selection_not_supported": {
+      "message": "The Fellow API does not support remote profile switching."
     }
   }
 }

--- a/custom_components/fellow/strings.json
+++ b/custom_components/fellow/strings.json
@@ -255,7 +255,7 @@
       "message": "Provide profile_name or profile_id."
     },
     "provide_schedule_profile": {
-      "message": "Provide profileName or profileId."
+      "message": "Provide a profile name or profile ID."
     },
     "schedule_id_required": {
       "message": "schedule_id is required."

--- a/custom_components/fellow/strings.json
+++ b/custom_components/fellow/strings.json
@@ -1,0 +1,238 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up Fellow Aiden",
+        "description": "Enter your Fellow Aiden account credentials.",
+        "data": {
+          "email": "Email",
+          "password": "Password"
+        },
+        "data_description": {
+          "email": "The email address you use to sign in to the Fellow app.",
+          "password": "Your Fellow account password."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate Fellow Aiden",
+        "description": "Your credentials have expired. Enter your current Fellow account password.",
+        "data": {
+          "password": "Password"
+        },
+        "data_description": {
+          "password": "Your current Fellow account password."
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Fellow Aiden",
+        "description": "Update your Fellow Aiden account credentials.",
+        "data": {
+          "email": "Email",
+          "password": "Password"
+        },
+        "data_description": {
+          "email": "The email address you use to sign in to the Fellow app.",
+          "password": "Your Fellow account password."
+        }
+      }
+    },
+    "error": {
+      "auth": "Invalid email or password.",
+      "cannot_connect": "Could not connect to Fellow servers. Try again later.",
+      "unknown": "An unexpected error occurred."
+    },
+    "abort": {
+      "already_configured": "This account is already configured.",
+      "reauth_successful": "Re-authentication successful.",
+      "wrong_account": "This is a different Fellow account than the one originally configured.",
+      "reconfigure_successful": "Reconfiguration successful."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Fellow Aiden options",
+        "description": "Adjust polling settings. Changing the interval restarts the integration.",
+        "data": {
+          "update_interval_seconds": "Update interval (seconds)"
+        },
+        "data_description": {
+          "update_interval_seconds": "How often to poll the Fellow cloud API. Minimum 30 seconds, default 60."
+        }
+      }
+    },
+    "error": {
+      "too_fast": "Update interval must be at least 30 seconds."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "chime_volume": { "name": "Chime volume" },
+      "total_brews": { "name": "Total brews" },
+      "total_water_volume": { "name": "Total water volume" },
+      "last_brew_volume": { "name": "Last brew volume" },
+      "average_water_per_brew": { "name": "Average water per brew" },
+      "last_brew_start_time": { "name": "Last brew start time" },
+      "last_brew_end_time": { "name": "Last brew end time" },
+      "last_brew_duration": { "name": "Last brew duration" },
+      "average_time_between_brews": { "name": "Average time between brews" },
+      "last_brew_time": { "name": "Last brew time" },
+      "total_water_today": { "name": "Water used today" },
+      "total_water_this_week": { "name": "Water used this week" },
+      "total_water_this_month": { "name": "Water used this month" },
+      "average_brew_duration": { "name": "Average brew duration" },
+      "most_popular_profile": { "name": "Most popular profile" },
+      "current_profile": { "name": "Current profile" },
+      "basket": { "name": "Basket" }
+    },
+    "binary_sensor": {
+      "brewing": { "name": "Brewing" },
+      "carafe_inserted": { "name": "Carafe" },
+      "heater": { "name": "Heater" },
+      "lid": { "name": "Lid" },
+      "missing_water": { "name": "Missing water" }
+    },
+    "select": {
+      "profiles": { "name": "Profiles" }
+    }
+  },
+  "services": {
+    "create_profile": {
+      "name": "Create brew profile",
+      "description": "Create a new brew profile on the Fellow Aiden.",
+      "fields": {
+        "profile_type": {
+          "name": "Profile type",
+          "description": "Numeric profile type."
+        },
+        "title": {
+          "name": "Profile title",
+          "description": "Name of the brew profile."
+        },
+        "ratio": {
+          "name": "Brew ratio",
+          "description": "Coffee-to-water ratio (14-20 in 0.5 steps)."
+        },
+        "bloom_enabled": {
+          "name": "Bloom enabled",
+          "description": "Whether to use a bloom phase."
+        },
+        "bloom_ratio": {
+          "name": "Bloom ratio",
+          "description": "Water used in bloom relative to coffee weight (1.0-3.0)."
+        },
+        "bloom_duration": {
+          "name": "Bloom duration",
+          "description": "Bloom phase duration in seconds (1-120)."
+        },
+        "bloom_temperature": {
+          "name": "Bloom temperature",
+          "description": "Bloom phase temperature in Celsius (50-99)."
+        },
+        "ss_pulses_enabled": {
+          "name": "Single serve pulses enabled",
+          "description": "Enable pulses for single serve brewing."
+        },
+        "ss_pulses_number": {
+          "name": "Single serve pulse count",
+          "description": "Number of single serve pulses (1-10)."
+        },
+        "ss_pulses_interval": {
+          "name": "Single serve pulse interval",
+          "description": "Seconds between single serve pulses (5-60)."
+        },
+        "ss_pulse_temperatures": {
+          "name": "Single serve pulse temperatures",
+          "description": "Temperature list for each single serve pulse, e.g. [96, 97, 98]."
+        },
+        "batch_pulses_enabled": {
+          "name": "Batch pulses enabled",
+          "description": "Enable batch brewing pulses."
+        },
+        "batch_pulses_number": {
+          "name": "Batch pulse count",
+          "description": "Number of batch pulses (1-10)."
+        },
+        "batch_pulses_interval": {
+          "name": "Batch pulse interval",
+          "description": "Seconds between batch pulses (5-60)."
+        },
+        "batch_pulse_temperatures": {
+          "name": "Batch pulse temperatures",
+          "description": "Temperature list for each batch pulse, e.g. [96, 97]."
+        }
+      }
+    },
+    "delete_profile": {
+      "name": "Delete brew profile",
+      "description": "Delete a brew profile by ID.",
+      "fields": {
+        "profile_id": {
+          "name": "Profile ID",
+          "description": "ID of the profile to delete (e.g. 'p1')."
+        }
+      }
+    },
+    "create_schedule": {
+      "name": "Create brew schedule",
+      "description": "Create a brewing schedule. Make sure a carafe or cup is in place before the scheduled time.",
+      "fields": {
+        "monday": { "name": "Monday", "description": "Brew on Monday." },
+        "tuesday": { "name": "Tuesday", "description": "Brew on Tuesday." },
+        "wednesday": { "name": "Wednesday", "description": "Brew on Wednesday." },
+        "thursday": { "name": "Thursday", "description": "Brew on Thursday." },
+        "friday": { "name": "Friday", "description": "Brew on Friday." },
+        "saturday": { "name": "Saturday", "description": "Brew on Saturday." },
+        "sunday": { "name": "Sunday", "description": "Brew on Sunday." },
+        "time": { "name": "Time", "description": "Time of day (HH:MM:SS)." },
+        "amount_of_water": { "name": "Water amount (mL)", "description": "Water to use (150-1500 mL)." },
+        "profile_name": { "name": "Profile name", "description": "Name of the brew profile to use." },
+        "profile_id": { "name": "Profile ID", "description": "Profile ID, alternative to name (e.g. 'p1')." },
+        "enabled": { "name": "Enabled", "description": "Whether the schedule starts enabled." }
+      }
+    },
+    "delete_schedule": {
+      "name": "Delete brew schedule",
+      "description": "Delete a schedule by ID.",
+      "fields": {
+        "schedule_id": { "name": "Schedule ID", "description": "ID of the schedule to delete." }
+      }
+    },
+    "toggle_schedule": {
+      "name": "Toggle brew schedule",
+      "description": "Enable or disable a schedule.",
+      "fields": {
+        "schedule_id": { "name": "Schedule ID", "description": "ID of the schedule." },
+        "enabled": { "name": "Enabled", "description": "True to enable, false to disable." }
+      }
+    },
+    "list_profiles": {
+      "name": "List profiles",
+      "description": "Returns all brew profiles with their names and IDs."
+    },
+    "get_profile_details": {
+      "name": "Get profile details",
+      "description": "Returns full details for a profile.",
+      "fields": {
+        "profile_name": { "name": "Profile name", "description": "Name of the profile." },
+        "profile_id": { "name": "Profile ID", "description": "ID of the profile (alternative to name)." }
+      }
+    },
+    "reset_water_tracking": {
+      "name": "Reset water tracking",
+      "description": "Resets the water usage baseline. Period sensors will read 0 until new usage is recorded."
+    },
+    "list_schedules": {
+      "name": "List schedules",
+      "description": "Returns all brew schedules."
+    },
+    "debug_water_usage": {
+      "name": "Debug water usage",
+      "description": "Returns raw water usage history for troubleshooting."
+    },
+    "refresh_and_log_data": {
+      "name": "Refresh and log data",
+      "description": "Forces a data refresh and returns the full API response."
+    }
+  }
+}

--- a/custom_components/fellow/strings.json
+++ b/custom_components/fellow/strings.json
@@ -101,7 +101,7 @@
       "name": "Create brew profile",
       "description": "Create a new brew profile on the Fellow Aiden.",
       "fields": {
-        "profileType": {
+        "profile_type": {
           "name": "Profile type",
           "description": "Numeric profile type."
         },
@@ -113,51 +113,51 @@
           "name": "Brew ratio",
           "description": "Coffee-to-water ratio (14-20 in 0.5 steps)."
         },
-        "bloomEnabled": {
+        "bloom_enabled": {
           "name": "Bloom enabled",
           "description": "Whether to use a bloom phase."
         },
-        "bloomRatio": {
+        "bloom_ratio": {
           "name": "Bloom ratio",
           "description": "Water used in bloom relative to coffee weight (1.0-3.0)."
         },
-        "bloomDuration": {
+        "bloom_duration": {
           "name": "Bloom duration",
           "description": "Bloom phase duration in seconds (1-120)."
         },
-        "bloomTemperature": {
+        "bloom_temperature": {
           "name": "Bloom temperature",
           "description": "Bloom phase temperature in Celsius (50-99)."
         },
-        "ssPulsesEnabled": {
+        "ss_pulses_enabled": {
           "name": "Single serve pulses enabled",
           "description": "Enable pulses for single serve brewing."
         },
-        "ssPulsesNumber": {
+        "ss_pulses_number": {
           "name": "Single serve pulse count",
           "description": "Number of single serve pulses (1-10)."
         },
-        "ssPulsesInterval": {
+        "ss_pulses_interval": {
           "name": "Single serve pulse interval",
           "description": "Seconds between single serve pulses (5-60)."
         },
-        "ssPulseTemperatures": {
+        "ss_pulse_temperatures": {
           "name": "Single serve pulse temperatures",
           "description": "Temperature list for each single serve pulse, e.g. [96, 97, 98]."
         },
-        "batchPulsesEnabled": {
+        "batch_pulses_enabled": {
           "name": "Batch pulses enabled",
           "description": "Enable batch brewing pulses."
         },
-        "batchPulsesNumber": {
+        "batch_pulses_number": {
           "name": "Batch pulse count",
           "description": "Number of batch pulses (1-10)."
         },
-        "batchPulsesInterval": {
+        "batch_pulses_interval": {
           "name": "Batch pulse interval",
           "description": "Seconds between batch pulses (5-60)."
         },
-        "batchPulseTemperatures": {
+        "batch_pulse_temperatures": {
           "name": "Batch pulse temperatures",
           "description": "Temperature list for each batch pulse, e.g. [96, 97]."
         }

--- a/custom_components/fellow/strings.json
+++ b/custom_components/fellow/strings.json
@@ -234,5 +234,55 @@
       "name": "Refresh and log data",
       "description": "Forces a data refresh and returns the full API response."
     }
+  },
+  "exceptions": {
+    "no_integrations": {
+      "message": "No Fellow Aiden integrations configured."
+    },
+    "not_loaded": {
+      "message": "Fellow Aiden integration is not loaded. Check Settings > Integrations."
+    },
+    "profile_id_required": {
+      "message": "profile_id is required."
+    },
+    "profile_not_found": {
+      "message": "Profile \"{profile}\" not found. Available: {available}."
+    },
+    "no_profiles": {
+      "message": "No profiles available."
+    },
+    "provide_profile_id_or_name": {
+      "message": "Provide profile_name or profile_id."
+    },
+    "provide_schedule_profile": {
+      "message": "Provide profileName or profileId."
+    },
+    "schedule_id_required": {
+      "message": "schedule_id is required."
+    },
+    "time_required": {
+      "message": "'time' is required."
+    },
+    "bad_time_format": {
+      "message": "Bad time format: \"{time_str}\". Use HH:MM:SS."
+    },
+    "create_profile_failed": {
+      "message": "Failed to create profile: {error}"
+    },
+    "delete_profile_failed": {
+      "message": "Failed to delete profile: {error}"
+    },
+    "create_schedule_failed": {
+      "message": "Failed to create schedule: {error}"
+    },
+    "delete_schedule_failed": {
+      "message": "Failed to delete schedule: {error}"
+    },
+    "toggle_schedule_failed": {
+      "message": "Failed to toggle schedule: {error}"
+    },
+    "reset_water_failed": {
+      "message": "Failed to reset water tracking: {error}"
+    }
   }
 }

--- a/custom_components/fellow/translations/en.json
+++ b/custom_components/fellow/translations/en.json
@@ -7,218 +7,285 @@
         "data": {
           "email": "Email",
           "password": "Password"
+        },
+        "data_description": {
+          "email": "The email address you use to sign in to the Fellow app.",
+          "password": "Your Fellow account password."
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate Fellow Aiden",
+        "description": "Your credentials have expired. Enter your current Fellow account password.",
+        "data": {
+          "password": "Password"
+        },
+        "data_description": {
+          "password": "Your current Fellow account password."
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure Fellow Aiden",
+        "description": "Update your Fellow Aiden account credentials.",
+        "data": {
+          "email": "Email",
+          "password": "Password"
+        },
+        "data_description": {
+          "email": "The email address you use to sign in to the Fellow app.",
+          "password": "Your Fellow account password."
         }
       }
     },
     "error": {
-      "auth": "Invalid email or password"
+      "auth": "Invalid email or password.",
+      "cannot_connect": "Could not connect to Fellow servers. Try again later.",
+      "unknown": "An unexpected error occurred."
+    },
+    "abort": {
+      "already_configured": "This account is already configured.",
+      "reauth_successful": "Re-authentication successful.",
+      "wrong_account": "This is a different Fellow account than the one originally configured.",
+      "reconfigure_successful": "Reconfiguration successful."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Configure Fellow Aiden Advanced Options",
-        "description": "Adjust advanced settings. Note: Changing the update interval will restart the integration.",
+        "title": "Fellow Aiden options",
+        "description": "Adjust polling settings. Changing the interval restarts the integration.",
         "data": {
-          "update_interval_seconds": "Update Interval (seconds)"
+          "update_interval_seconds": "Update interval (seconds)"
         },
         "data_description": {
-          "update_interval_seconds": "How often to poll the Fellow Aiden cloud (minimum 30 seconds, default 60 seconds). Lower values provide more responsive data but may impact performance."
+          "update_interval_seconds": "How often to poll the Fellow cloud API. Minimum 30 seconds, default 60."
         }
       }
     },
     "error": {
-      "too_fast": "Update interval must be at least 30 seconds to avoid overloading the Fellow servers"
+      "too_fast": "Update interval must be at least 30 seconds."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "chime_volume": { "name": "Chime volume" },
+      "total_brews": { "name": "Total brews" },
+      "total_water_volume": { "name": "Total water volume" },
+      "last_brew_volume": { "name": "Last brew volume" },
+      "average_water_per_brew": { "name": "Average water per brew" },
+      "last_brew_start_time": { "name": "Last brew start time" },
+      "last_brew_end_time": { "name": "Last brew end time" },
+      "last_brew_duration": { "name": "Last brew duration" },
+      "average_time_between_brews": { "name": "Average time between brews" },
+      "last_brew_time": { "name": "Last brew time" },
+      "total_water_today": { "name": "Water used today" },
+      "total_water_this_week": { "name": "Water used this week" },
+      "total_water_this_month": { "name": "Water used this month" },
+      "average_brew_duration": { "name": "Average brew duration" },
+      "most_popular_profile": { "name": "Most popular profile" },
+      "current_profile": { "name": "Current profile" },
+      "basket": { "name": "Basket" }
+    },
+    "binary_sensor": {
+      "brewing": { "name": "Brewing" },
+      "carafe_inserted": { "name": "Carafe" },
+      "heater": { "name": "Heater" },
+      "lid": { "name": "Lid" },
+      "missing_water": { "name": "Missing water" }
+    },
+    "select": {
+      "profiles": { "name": "Profiles" }
     }
   },
   "services": {
     "create_profile": {
-      "name": "Create Brew Profile",
-      "description": "Create a new brew profile on the Fellow Aiden device.",
+      "name": "Create brew profile",
+      "description": "Create a new brew profile on the Fellow Aiden.",
       "fields": {
         "profile_type": {
-          "name": "Profile Type",
-          "description": "Numeric profile type"
+          "name": "Profile type",
+          "description": "Numeric profile type."
         },
         "title": {
-          "name": "Profile Title",
-          "description": "Name of the brew profile"
+          "name": "Profile title",
+          "description": "Name of the brew profile."
         },
         "ratio": {
-          "name": "Brew Ratio",
-          "description": "Coffee-to-water ratio (e.g. 16 → 1:16 ratio). Must be one of 14–20 in 0.5 steps."
+          "name": "Brew ratio",
+          "description": "Coffee-to-water ratio (14-20 in 0.5 steps)."
         },
         "bloom_enabled": {
-          "name": "Bloom Enabled",
-          "description": "Should the bloom phase be used?"
+          "name": "Bloom enabled",
+          "description": "Whether to use a bloom phase."
         },
         "bloom_ratio": {
-          "name": "Bloom Ratio",
-          "description": "Amount of water used in bloom relative to coffee weight (1.0–3.0)."
+          "name": "Bloom ratio",
+          "description": "Water used in bloom relative to coffee weight (1.0-3.0)."
         },
         "bloom_duration": {
-          "name": "Bloom Duration (seconds)",
-          "description": "Duration of bloom phase, 1–120 seconds."
+          "name": "Bloom duration",
+          "description": "Bloom phase duration in seconds (1-120)."
         },
         "bloom_temperature": {
-          "name": "Bloom Temperature (°C)",
-          "description": "Temperature for bloom phase, 50–99°C."
+          "name": "Bloom temperature",
+          "description": "Bloom phase temperature in Celsius (50-99)."
         },
         "ss_pulses_enabled": {
-          "name": "Single Serve Pulses Enabled",
-          "description": "Enable pulses for Single Serve brewing?"
+          "name": "Single serve pulses enabled",
+          "description": "Enable pulses for single serve brewing."
         },
         "ss_pulses_number": {
-          "name": "Single Serve Pulses Number",
-          "description": "How many pulses for Single Serve brewing? (1–10)."
+          "name": "Single serve pulse count",
+          "description": "Number of single serve pulses (1-10)."
         },
         "ss_pulses_interval": {
-          "name": "Single Serve Pulses Interval (seconds)",
-          "description": "Time between Single Serve pulses, 5–60."
+          "name": "Single serve pulse interval",
+          "description": "Seconds between single serve pulses (5-60)."
         },
         "ss_pulse_temperatures": {
-          "name": "Single Serve Pulse Temperatures",
-          "description": "A list of temperatures for each Single Serve pulse (e.g. [96, 97, 98])."
+          "name": "Single serve pulse temperatures",
+          "description": "Temperature list for each single serve pulse, e.g. [96, 97, 98]."
         },
         "batch_pulses_enabled": {
-          "name": "Batch Pulses Enabled",
-          "description": "Enable batch pulses?"
+          "name": "Batch pulses enabled",
+          "description": "Enable batch brewing pulses."
         },
         "batch_pulses_number": {
-          "name": "Batch Pulses Number",
-          "description": "Number of batch pulses (1–10)."
+          "name": "Batch pulse count",
+          "description": "Number of batch pulses (1-10)."
         },
         "batch_pulses_interval": {
-          "name": "Batch Pulses Interval (seconds)",
-          "description": "Time between batch pulses, 5–60."
+          "name": "Batch pulse interval",
+          "description": "Seconds between batch pulses (5-60)."
         },
         "batch_pulse_temperatures": {
-          "name": "Batch Pulse Temperatures",
-          "description": "A list of temperatures for each batch pulse (e.g. [96, 97])."
+          "name": "Batch pulse temperatures",
+          "description": "Temperature list for each batch pulse, e.g. [96, 97]."
         }
       }
     },
     "delete_profile": {
-      "name": "Delete Brew Profile",
+      "name": "Delete brew profile",
       "description": "Delete a brew profile by ID.",
       "fields": {
         "profile_id": {
           "name": "Profile ID",
-          "description": "ID of profile to delete (e.g. 'p1')"
+          "description": "ID of the profile to delete (e.g. 'p1')."
         }
       }
     },
     "create_schedule": {
-      "name": "Create Brew Schedule",
-      "description": "Create a new brew schedule on the Fellow Aiden device. ⚠️ WARNING: Ensure carafe/cup is in place before scheduled brew time to prevent spills!",
+      "name": "Create brew schedule",
+      "description": "Create a brewing schedule. Make sure a carafe or cup is in place before the scheduled time.",
       "fields": {
-        "monday": {
-          "name": "Monday",
-          "description": "Enable brewing on Monday"
-        },
-        "tuesday": {
-          "name": "Tuesday",
-          "description": "Enable brewing on Tuesday"
-        },
-        "wednesday": {
-          "name": "Wednesday",
-          "description": "Enable brewing on Wednesday"
-        },
-        "thursday": {
-          "name": "Thursday",
-          "description": "Enable brewing on Thursday"
-        },
-        "friday": {
-          "name": "Friday",
-          "description": "Enable brewing on Friday"
-        },
-        "saturday": {
-          "name": "Saturday",
-          "description": "Enable brewing on Saturday"
-        },
-        "sunday": {
-          "name": "Sunday",
-          "description": "Enable brewing on Sunday"
-        },
-        "time": {
-          "name": "Time",
-          "description": "Time of day to run the schedule."
-        },
-        "amount_of_water": {
-          "name": "Water Amount (mL)",
-          "description": "Amount of water to use for brewing (150-1500 mL)."
-        },
-        "profile_name": {
-          "name": "Profile Name",
-          "description": "Name of the brew profile to use. Find names in the 'Fellow Aiden Profiles' dropdown."
-        },
-        "profile_id": {
-          "name": "Profile ID (Alternative)",
-          "description": "ID of the brew profile to use instead of its name (e.g. 'p1')."
-        },
-        "enabled": {
-          "name": "Enabled",
-          "description": "Whether the schedule should be enabled."
-        }
+        "monday": { "name": "Monday", "description": "Brew on Monday." },
+        "tuesday": { "name": "Tuesday", "description": "Brew on Tuesday." },
+        "wednesday": { "name": "Wednesday", "description": "Brew on Wednesday." },
+        "thursday": { "name": "Thursday", "description": "Brew on Thursday." },
+        "friday": { "name": "Friday", "description": "Brew on Friday." },
+        "saturday": { "name": "Saturday", "description": "Brew on Saturday." },
+        "sunday": { "name": "Sunday", "description": "Brew on Sunday." },
+        "time": { "name": "Time", "description": "Time of day (HH:MM:SS)." },
+        "amount_of_water": { "name": "Water amount (mL)", "description": "Water to use (150-1500 mL)." },
+        "profile_name": { "name": "Profile name", "description": "Name of the brew profile to use." },
+        "profile_id": { "name": "Profile ID", "description": "Profile ID, alternative to name (e.g. 'p1')." },
+        "enabled": { "name": "Enabled", "description": "Whether the schedule starts enabled." }
       }
     },
     "delete_schedule": {
-      "name": "Delete Brew Schedule",
-      "description": "Delete a brew schedule by its ID.",
+      "name": "Delete brew schedule",
+      "description": "Delete a schedule by ID.",
       "fields": {
-        "schedule_id": {
-          "name": "Schedule ID",
-          "description": "ID of the schedule to delete."
-        }
+        "schedule_id": { "name": "Schedule ID", "description": "ID of the schedule to delete." }
       }
     },
     "toggle_schedule": {
-      "name": "Enable/Disable Brew Schedule",
-      "description": "Enable or disable a brew schedule by its ID.",
+      "name": "Toggle brew schedule",
+      "description": "Enable or disable a schedule.",
       "fields": {
-        "schedule_id": {
-          "name": "Schedule ID",
-          "description": "ID of the schedule to toggle."
-        },
-        "enabled": {
-          "name": "Enabled",
-          "description": "Enable or disable the schedule."
-        }
+        "schedule_id": { "name": "Schedule ID", "description": "ID of the schedule." },
+        "enabled": { "name": "Enabled", "description": "True to enable, false to disable." }
       }
     },
     "list_profiles": {
-      "name": "List All Profiles",
-      "description": "Lists all available brew profiles with their names and IDs."
+      "name": "List profiles",
+      "description": "Returns all brew profiles with their names and IDs."
     },
     "get_profile_details": {
-      "name": "Get Profile Details",
-      "description": "Gets detailed information about a specific profile by its name or ID.",
+      "name": "Get profile details",
+      "description": "Returns full details for a profile.",
       "fields": {
-        "profile_name": {
-          "name": "Profile Name",
-          "description": "Name of the profile to get details for."
-        },
-        "profile_id": {
-          "name": "Profile ID (Alternative)",
-          "description": "ID of the profile to get details for (alternative to name)."
-        }
+        "profile_name": { "name": "Profile name", "description": "Name of the profile." },
+        "profile_id": { "name": "Profile ID", "description": "ID of the profile (alternative to name)." }
       }
     },
     "reset_water_tracking": {
-      "name": "Reset Water Usage Tracking",
-      "description": "Resets water usage tracking to start fresh. Use this if historical water sensors seem incorrect."
+      "name": "Reset water tracking",
+      "description": "Resets the water usage baseline. Period sensors will read 0 until new usage is recorded."
     },
     "list_schedules": {
-      "name": "List All Schedules",
-      "description": "Lists all available brew schedules with their details."
+      "name": "List schedules",
+      "description": "Returns all brew schedules."
     },
     "debug_water_usage": {
-      "name": "Debug Water Usage",
-      "description": "Logs detailed water usage history for troubleshooting."
+      "name": "Debug water usage",
+      "description": "Returns raw water usage history for troubleshooting."
     },
     "refresh_and_log_data": {
-      "name": "Refresh and Log Full Data",
-      "description": "Manually refreshes all data from the Fellow API and logs the complete response."
+      "name": "Refresh and log data",
+      "description": "Forces a data refresh and returns the full API response."
+    }
+  },
+  "exceptions": {
+    "no_integrations": {
+      "message": "No Fellow Aiden integrations configured."
+    },
+    "not_loaded": {
+      "message": "Fellow Aiden integration is not loaded. Check Settings > Integrations."
+    },
+    "profile_id_required": {
+      "message": "profile_id is required."
+    },
+    "profile_not_found": {
+      "message": "Profile \"{profile}\" not found. Available: {available}."
+    },
+    "no_profiles": {
+      "message": "No profiles available."
+    },
+    "provide_profile_id_or_name": {
+      "message": "Provide a profile name or profile ID."
+    },
+    "provide_schedule_profile": {
+      "message": "Provide a profile name or profile ID."
+    },
+    "schedule_id_required": {
+      "message": "schedule_id is required."
+    },
+    "time_required": {
+      "message": "'time' is required."
+    },
+    "bad_time_format": {
+      "message": "Bad time format: \"{time_str}\". Use HH:MM:SS."
+    },
+    "create_profile_failed": {
+      "message": "Failed to create profile: {error}"
+    },
+    "delete_profile_failed": {
+      "message": "Failed to delete profile: {error}"
+    },
+    "create_schedule_failed": {
+      "message": "Failed to create schedule: {error}"
+    },
+    "delete_schedule_failed": {
+      "message": "Failed to delete schedule: {error}"
+    },
+    "toggle_schedule_failed": {
+      "message": "Failed to toggle schedule: {error}"
+    },
+    "reset_water_failed": {
+      "message": "Failed to reset water tracking: {error}"
+    },
+    "profile_selection_not_supported": {
+      "message": "The Fellow API does not support remote profile switching."
     }
   }
 }


### PR DESCRIPTION
This reworks the integration to pass the Home Assistant [integration quality scale](https://developers.home-assistant.io/docs/core/integration-quality-scale/) through Gold.

## What changed

**Bronze fixes:**
- Store the coordinator in `ConfigEntry.runtime_data` instead of the `hass.data` dict.
- Register services in `async_setup()`, not `async_setup_entry()`.
- All entities use `has_entity_name = True` with `translation_key` (no more hardcoded "Aiden …" names).
- New `strings.json` with `data_description` for config flow fields.
- `DeviceInfo` dataclass replaces the raw dict in `base_entity.py`.
- Drop the non-standard `wifi_ssid` connection tuple from device info.

**Silver fixes:**
- Reauth flow (`async_step_reauth` / `async_step_reauth_confirm`).
- `PARALLEL_UPDATES = 0` on all platform modules.
- Service handlers raise `ServiceValidationError` or `HomeAssistantError` on every failure path.
- `ConfigEntryAuthFailed` on coordinator re-auth failure (triggers the reauth UI).
- `async_unload_entry` simplified now that `hass.data` is gone.

**Gold fixes:**
- `diagnostics.py` with redacted sensitive fields.
- `SensorDeviceClass` (VOLUME, DURATION, TIMESTAMP) and `SensorStateClass` (TOTAL_INCREASING) on sensors.
- `BinarySensorDeviceClass.PRESENCE` / `.HEAT` for carafe and heater.
- `EntityCategory.DIAGNOSTIC` and `entity_registry_enabled_default = False` on noisy sensors.
- `icons.json` for all entities and services (removes `_attr_icon` from Python).
- `exception-translations`: every raised exception uses `translation_domain` + `translation_key`.
- Reconfigure flow (`async_step_reconfigure`).
- Options flow modernized (dropped the deprecated `__init__` pattern).
- Moved `AidenBasketSensor` (a `SensorEntity`) out of `binary_sensor.py` into `sensor.py`.

**Docs (README):**
- Removal instructions, data update explanation, supported devices, entity/service tables, automation examples, known limitations, use cases, expanded troubleshooting.

**Cleanup:**
- All f-string logging replaced with lazy `%s` formatting.
- Config flow uses `TextSelector` with proper types.

## Breaking change

Entity IDs will change. With `has_entity_name`, HA generates IDs from `{device_name}_{entity_name}` instead of `aiden_{entity_name}`. Automations referencing old entity IDs will need updating.

## What's left for full Gold

- `config-flow-test-coverage` and `test-coverage` (no tests yet).
- `brands` (brand assets submitted to the HA brands repo).
- `dependency-transparency` (vendored library isn't on PyPI).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README reorganized: installation parameters table (email/password), update-interval option (60s default, 30–300s), polling/data retention, removal workflow, supported devices/features, automation examples, troubleshooting, and sample YAML.

* **New Features**
  * Reauthentication/reconfigure flows, diagnostics export, comprehensive service-based profile & schedule management, UI icons, and full localization strings.

* **Improvements**
  * Translation-key driven entity names, added basket sensor, richer sensor metadata and device info, standardized service field names to snake_case, and expanded options for polling interval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->