### PR TITLE
Fix high-severity API error handling and auth recursion

### DIFF
--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -192,6 +192,8 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             result = await self.hass.async_add_executor_job(
                 self.api.delete_profile_by_id, profile_id
             )
+            if result is False:
+                raise ValueError("Profile deletion failed")
             _LOGGER.debug("Profile deletion result: %s", result)
         except Exception:
             _LOGGER.exception("Profile deletion failed")
@@ -208,6 +210,8 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             result = await self.hass.async_add_executor_job(
                 self.api.create_schedule, schedule_data
             )
+            if result is False:
+                raise ValueError("Schedule creation validation failed")
             _LOGGER.debug("Schedule creation result: %s", result)
         except Exception:
             _LOGGER.exception("Schedule creation failed")
@@ -224,6 +228,8 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             result = await self.hass.async_add_executor_job(
                 self.api.delete_schedule_by_id, schedule_id
             )
+            if result is False:
+                raise ValueError("Schedule deletion failed")
             _LOGGER.debug("Schedule deletion result: %s", result)
         except Exception:
             _LOGGER.exception("Schedule deletion failed")
@@ -240,6 +246,8 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             result = await self.hass.async_add_executor_job(
                 self.api.toggle_schedule, schedule_id, enabled
             )
+            if result is False:
+                raise ValueError("Schedule toggle failed")
             _LOGGER.debug("Schedule toggle result: %s", result)
         except Exception:
             _LOGGER.exception("Schedule toggle failed")


### PR DESCRIPTION
## Summary
- add centralized HTTP response validation and one-shot reauth retry helper in the vendored Fellow client
- prevent recursive auth/device calls by splitting auth refresh from device fetch
- handle empty/malformed device-list responses explicitly instead of indexing blindly
- make schedule/profile create-delete-toggle paths raise on validation or non-2xx API failures
- treat falsey mutation results in the coordinator as failures so Home Assistant services do not report false success

## Validation
- uv run python -m compileall custom_components/fellow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling to provide clear, descriptive messages when operations fail instead of silent failures
  * Added automatic retry mechanism for requests when authentication credentials need refresh
  * Enhanced data validation to ensure more reliable operations and prevent unexpected behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->