### PR TITLE
Fix repeated auth log spam on token expiry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ The integration includes a vendored copy of the Fellow Aiden library in `fellow_
 - **Lazy Loading**: Profiles and schedules are fetched on-demand via `@property` decorators
 - **Performance**: Profile validation removed from delete operations for speed
 
-**Important**: The coordinator uses private method hacks (`_FellowAiden__device()`, `_FellowAiden__auth()`) to force data refreshes, as the library doesn't expose public refresh methods.
+**Public API**: The library exposes `fetch_device()` and `refresh()` methods for the coordinator to trigger data refreshes and re-authentication respectively. Token refresh is handled automatically inside `_request_with_reauth()` using the stored refresh token, with fallback to full re-login.
 
 ### Services
 
@@ -67,8 +67,9 @@ Service definitions are in `services.yaml` with extensive parameter validation.
 ### Authentication & Error Handling
 
 - Initial auth happens during config flow setup
-- Coordinator handles 401 responses by triggering re-authentication
-- Library automatically retries failed requests after re-auth
+- On 401, `_request_with_reauth()` first tries a lightweight token refresh via the stored refresh token, then falls back to full email/password re-login
+- Token expiry is expected and logged at DEBUG level; only persistent auth failures log at WARNING
+- The coordinator delegates all auth retry logic to the library — no redundant retry wrapping
 - Update failures are logged but don't crash the integration
 
 ## Testing & Debugging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ The integration includes a vendored copy of the Fellow Aiden library in `fellow_
 - **Lazy Loading**: Profiles and schedules are fetched on-demand via `@property` decorators
 - **Performance**: Profile validation removed from delete operations for speed
 
-**Public API**: The library exposes `fetch_device()` and `refresh()` methods for the coordinator to trigger data refreshes and re-authentication respectively. Token refresh is handled automatically inside `_request_with_reauth()` using the stored refresh token, with fallback to full re-login.
+**Public API**: The library exposes `fetch_device()` and `authenticate()` methods for the coordinator to trigger data refreshes and re-authentication respectively. Token refresh is handled automatically inside `_request_with_reauth()` using the stored refresh token, with fallback to full re-login.
 
 ### Services
 

--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .fellow_aiden import FellowAiden
+from .fellow_aiden import FellowAiden, FellowAuthError
 from .brew_history import BrewHistoryManager
 from .const import DEFAULT_UPDATE_INTERVAL_MINUTES
 
@@ -90,13 +90,12 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             _LOGGER.debug("Fetching device data")
             self.api.fetch_device()
+        except FellowAuthError as err:
+            raise ConfigEntryAuthFailed(  # noqa: TRY003
+                f"Authentication failed: {err}"
+            ) from err
         except Exception as err:
-            err_message = str(err).lower()
-            if "email or password incorrect" in err_message:
-                raise ConfigEntryAuthFailed(
-                    f"Authentication failed: {err}"
-                ) from err
-            raise UpdateFailed(
+            raise UpdateFailed(  # noqa: TRY003
                 f"Device fetch failed: {err}"
             ) from err
 

--- a/custom_components/fellow/fellow_aiden/__init__.py
+++ b/custom_components/fellow/fellow_aiden/__init__.py
@@ -164,7 +164,6 @@ class FellowAiden:
 
         self._ensure_success(response, "Authentication")
         parsed = self._parse_response(response)
-        self._log.debug(parsed)
         if "accessToken" not in parsed or "refreshToken" not in parsed:
             raise Exception(f"Authentication response missing tokens: {parsed}")
 
@@ -470,10 +469,6 @@ class FellowAiden:
     def fetch_device(self):
         """Public method to re-fetch device data from the cloud."""
         self.__device()
-
-    def refresh(self):
-        """Public method to re-authenticate and refresh device data."""
-        self.authenticate()
 
     def authenticate(self):
         """Public method to reauthenticate the user.


### PR DESCRIPTION
## Problem

Users report "Unauthorized response received. Attempting to reauthenticate..." logged **106 times in ~3 hours** (ref #24). Fellow API access tokens have a finite lifetime (~15 min), so a 401 on every few polls is expected and normal. Three things made this painful:

1. **Every token expiry logged at WARNING level** — the direct cause of the log spam. The `_request_with_reauth()` method logged `self._log.warning("Unauthorized response received...")` on every 401, even though this is routine.

2. **Refresh token stored but never used** — the API returns a `refreshToken` on login which was saved to `self._refresh` but never actually used. Every 401 triggered a full email/password re-login instead of a lightweight token refresh.

3. **Redundant double-retry in coordinator** — `_request_with_reauth()` already handles 401→re-auth→retry. The coordinator's `_fetch()` wrapped this in its own try/except/re-auth/retry block, meaning a single device fetch could trigger up to 4 authentication attempts.

## Solution

**`fellow_aiden/__init__.py`:**
- Add `__refresh_auth()` method that attempts token refresh via `POST /auth/refresh` using the stored refresh token. Returns `False` on any failure, allowing graceful fallback to full re-login. If the endpoint doesn't exist on Fellow's API, this is a silent no-op.
- Rework `_request_with_reauth()`: on 401, try token refresh first → fall back to full re-login → retry the request. Log the initial 401 at **DEBUG** (routine). Only log **WARNING** if the retry still returns 401 (genuinely unexpected).
- Add public `fetch_device()` and `refresh()` methods to eliminate the private name-mangling hacks (`_FellowAiden__device()`, `_FellowAiden__auth()`) the coordinator was using.

**`coordinator.py`:**
- Replace the 30-line try/except/re-auth/retry block with a single `self.api.fetch_device()` call. All auth retry logic is now handled inside the library where it belongs. The coordinator only inspects exceptions to detect "email or password incorrect" (triggers HA's reauth flow) or wraps other errors as `UpdateFailed`.

## Expected behavior after this change

- Token expiry → **DEBUG** log, silent refresh, no user-visible noise
- Refresh token works → no full re-login needed at all
- Refresh token doesn't work (endpoint missing or token expired) → falls back to full re-login, still at DEBUG level
- Credentials actually invalid → **WARNING** log + HA reauth flow triggered
- Net result: logs go from ~106 warnings/3hrs to near-zero under normal operation

## Test plan

- [ ] Deploy to HA, enable debug logging for `fellow` domain
- [ ] Monitor logs over several hours — 401s should appear at DEBUG, not WARNING
- [ ] Confirm all sensors continue updating together after token refresh cycles
- [ ] Verify HA reauth flow still triggers if credentials are changed/revoked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New public actions to manually fetch device data and trigger re-authentication.

* **Bug Fixes**
  * Automatic token refresh on 401 responses before falling back to full re-login; clearer logging for token expiry and persistent failures.

* **Improvements**
  * Simplified coordinator update flow and error mapping for clearer diagnostics during device sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->