### PR TITLE
Migrate `fellow_aiden` library from `requests` to `aiohttp`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,16 +38,18 @@ This is a Home Assistant custom integration for Fellow Aiden coffee brewers. The
 ### Fellow Aiden Library (Vendored)
 
 The integration includes a vendored copy of the Fellow Aiden library in `fellow_aiden/`:
-- **`__init__.py`**: Main `FellowAiden` class with API methods
+- **`__init__.py`**: Main `FellowAiden` async class with API methods
 - **`profile.py`**: Pydantic models for coffee profiles
 - **`schedule.py`**: Pydantic models for brewing schedules
 
 **Key Features**:
-- **HTTP Retries**: Built-in retry logic for failed requests (3 retries for 4xx/5xx errors)
-- **Lazy Loading**: Profiles and schedules are fetched on-demand via `@property` decorators
+- **Fully Async**: Uses `aiohttp` for all HTTP requests — no executor thread wrapping needed
+- **Injected Session**: Accepts an `aiohttp.ClientSession` (from HA's `async_get_clientsession`) for proper session management
+- **HTTP Retries**: Built-in retry logic for server errors (3 retries for 408/5xx)
+- **Lazy Loading**: Profiles and schedules are fetched on-demand via async `get_profiles()`/`get_schedules()` methods
 - **Performance**: Profile validation removed from delete operations for speed
 
-**Public API**: The library exposes `fetch_device()` and `authenticate()` methods for the coordinator to trigger data refreshes and re-authentication respectively. Token refresh is handled automatically inside `_request_with_reauth()` using the stored refresh token, with fallback to full re-login.
+**Public API**: Construction is lightweight — call `await api.authenticate()` after creating the instance to perform the initial login and device fetch. `await api.fetch_device()` triggers data refreshes. Token refresh is handled automatically inside `_request_with_reauth()` using the stored refresh token, with fallback to full re-login.
 
 ### Services
 
@@ -66,7 +68,8 @@ Service definitions are in `services.yaml` with extensive parameter validation.
 
 ### Authentication & Error Handling
 
-- Initial auth happens during config flow setup
+- Initial auth happens during config flow setup via `await _try_login(hass, email, password)`
+- The library is fully async — the coordinator calls `await self.api.fetch_device()` etc. directly, no executor jobs
 - On 401, `_request_with_reauth()` first tries a lightweight token refresh via the stored refresh token, then falls back to full email/password re-login
 - Token expiry is expected and logged at DEBUG level; only persistent auth failures log at WARNING
 - The coordinator delegates all auth retry logic to the library — no redundant retry wrapping

--- a/custom_components/fellow/config_flow.py
+++ b/custom_components/fellow/config_flow.py
@@ -8,7 +8,8 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import TextSelector, TextSelectorConfig, TextSelectorType
 
 from .fellow_aiden import FellowAiden
@@ -24,9 +25,11 @@ USER_SCHEMA = vol.Schema(
 )
 
 
-def _try_login(email: str, password: str) -> None:
-    """Attempt to authenticate. Raises on failure."""
-    FellowAiden(email, password)
+async def _try_login(hass: HomeAssistant, email: str, password: str) -> None:
+    """Attempt to authenticate asynchronously. Raises on failure."""
+    session = async_get_clientsession(hass)
+    api = FellowAiden(email, password, session)
+    await api.authenticate()
 
 
 class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -45,7 +48,7 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             email = user_input["email"]
             password = user_input["password"]
             try:
-                await self.hass.async_add_executor_job(_try_login, email, password)
+                await _try_login(self.hass, email, password)
             except Exception:
                 _LOGGER.exception("Authentication failed")
                 errors["base"] = "auth"
@@ -80,9 +83,7 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if self._reauth_email is None:
                 return self.async_abort(reason="unknown")
             try:
-                await self.hass.async_add_executor_job(
-                    _try_login, self._reauth_email, password
-                )
+                await _try_login(self.hass, self._reauth_email, password)
             except Exception:
                 _LOGGER.exception("Re-authentication failed")
                 errors["base"] = "auth"
@@ -117,7 +118,7 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             email = user_input["email"]
             password = user_input["password"]
             try:
-                await self.hass.async_add_executor_job(_try_login, email, password)
+                await _try_login(self.hass, email, password)
             except Exception:
                 _LOGGER.exception("Reconfigure authentication failed")
                 errors["base"] = "auth"

--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -46,7 +46,12 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Create the async API client and perform the initial refresh."""
         session = async_get_clientsession(self.hass)
         self.api = FellowAiden(self.email, self.password, session)
-        await self.api.authenticate()
+        try:
+            await self.api.authenticate()
+        except FellowAuthError as err:
+            raise ConfigEntryAuthFailed(
+                f"Authentication failed: {err}"
+            ) from err
         await super().async_config_entry_first_refresh()
 
     async def _async_update_data(self) -> dict[str, Any]:
@@ -73,6 +78,10 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             profiles = await self.api.get_profiles()
             device_config = self.api.get_device_config()
             schedules = await self.api.get_schedules()
+        except FellowAuthError as err:
+            raise ConfigEntryAuthFailed(
+                f"Authentication failed: {err}"
+            ) from err
         except Exception as err:
             raise UpdateFailed(  # noqa: TRY003
                 f"Data fetch failed: {err}"

--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -120,9 +120,12 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             len(profiles) if profiles else 0, len(schedules) if schedules else 0,
         )
 
-        # Update historical data with the new data
+        # Update historical data with the new data (non-fatal)
         _LOGGER.debug("Updating historical data")
-        await self.history_manager.async_update_data(device_config, profiles)
+        try:
+            await self.history_manager.async_update_data(device_config, profiles)
+        except Exception:
+            _LOGGER.warning("Failed to update historical data", exc_info=True)
 
         _LOGGER.debug("Data update completed successfully")
         return result

--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -8,6 +8,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .fellow_aiden import FellowAiden, FellowAuthError
@@ -20,7 +21,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator to fetch data from the Fellow Aiden cloud API."""
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry, email: str, password: str) -> None:
-        """Initialize with credentials, but do not block the event loop."""
+        """Initialize with credentials."""
         self.hass = hass
         self.email = email
         self.password = password
@@ -42,54 +43,22 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
 
     async def async_config_entry_first_refresh(self) -> None:
-        """Instantiate the library in an executor and do the initial refresh."""
-        def create_api() -> FellowAiden:
-            return FellowAiden(self.email, self.password)
-
-        self.api = await self.hass.async_add_executor_job(create_api)
+        """Create the async API client and perform the initial refresh."""
+        session = async_get_clientsession(self.hass)
+        self.api = FellowAiden(self.email, self.password, session)
+        await self.api.authenticate()
         await super().async_config_entry_first_refresh()
 
     async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch data from the library asynchronously."""
+        """Fetch data from the Fellow Aiden cloud API."""
         _LOGGER.debug("Starting data update cycle")
         if not self.api:
             _LOGGER.error("Fellow Aiden library not initialized")
             raise UpdateFailed("Fellow Aiden library not initialized")
 
         try:
-            _LOGGER.debug("Executing _fetch in executor")
-            verbose_logging = self._next_refresh_verbose
-            self._next_refresh_verbose = False
-            data = await self.hass.async_add_executor_job(self._fetch, verbose_logging)
-
-            # Update historical data with the new data
-            _LOGGER.debug("Updating historical data")
-            device_config = data.get("device_config", {})
-            profiles = data.get("profiles", [])
-            await self.history_manager.async_update_data(device_config, profiles)
-
-            _LOGGER.debug("Data update completed successfully")
-            return data
-        except UpdateFailed:
-            # If UpdateFailed was already raised, propagate it
-            _LOGGER.exception("UpdateFailed exception during data update")
-            raise
-        except ConfigEntryAuthFailed:
-            _LOGGER.warning("Authentication failed, triggering reauth flow")
-            raise
-        except Exception as err:
-            _LOGGER.exception("Unexpected error during data update: %s", err)
-            raise UpdateFailed(f"Unexpected error: {err}") from err
-
-    def _fetch(self, verbose_logging: bool = False) -> dict[str, Any]:
-        """Synchronous call to retrieve brewer info from the library.
-
-        Args:
-            verbose_logging: If True, log full API responses. If False, only log basic info.
-        """
-        try:
             _LOGGER.debug("Fetching device data")
-            self.api.fetch_device()
+            await self.api.fetch_device()
         except FellowAuthError as err:
             raise ConfigEntryAuthFailed(  # noqa: TRY003
                 f"Authentication failed: {err}"
@@ -100,9 +69,17 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ) from err
 
         brewer_name = self.api.get_display_name()
-        profiles = self.api.get_profiles()
-        device_config = self.api.get_device_config()
-        schedules = self.api.get_schedules()
+        try:
+            profiles = await self.api.get_profiles()
+            device_config = self.api.get_device_config()
+            schedules = await self.api.get_schedules()
+        except Exception as err:
+            raise UpdateFailed(  # noqa: TRY003
+                f"Data fetch failed: {err}"
+            ) from err
+
+        verbose_logging = self._next_refresh_verbose
+        self._next_refresh_verbose = False
 
         if verbose_logging:
             _LOGGER.info("=== Fellow Aiden API Response ===")
@@ -123,8 +100,6 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.error("Incomplete data fetched from Fellow Aiden.")
             raise UpdateFailed("Incomplete data fetched from Fellow Aiden.")
 
-        # Historical data will be updated in _async_update_data
-
         result = {
             "brewer_name": brewer_name,
             "profiles": profiles,
@@ -135,6 +110,12 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "Returning data: %d profiles, %d schedules",
             len(profiles) if profiles else 0, len(schedules) if schedules else 0,
         )
+
+        # Update historical data with the new data
+        _LOGGER.debug("Updating historical data")
+        await self.history_manager.async_update_data(device_config, profiles)
+
+        _LOGGER.debug("Data update completed successfully")
         return result
 
 
@@ -144,7 +125,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise RuntimeError("Fellow Aiden library not initialized")
         _LOGGER.debug("Creating profile with data: %s", profile_data)
         try:
-            result = await self.hass.async_add_executor_job(self.api.create_profile, profile_data)
+            result = await self.api.create_profile(profile_data)
             if result is False:
                 raise ValueError("Profile creation validation failed")
             _LOGGER.debug("Profile creation result: %s", result)
@@ -160,9 +141,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise RuntimeError("Fellow Aiden library not initialized")
         _LOGGER.debug("Deleting profile ID: %s", profile_id)
         try:
-            result = await self.hass.async_add_executor_job(
-                self.api.delete_profile_by_id, profile_id
-            )
+            result = await self.api.delete_profile_by_id(profile_id)
             if result is False:
                 raise ValueError("Profile deletion failed")
             _LOGGER.debug("Profile deletion result: %s", result)
@@ -178,9 +157,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise RuntimeError("Fellow Aiden library not initialized")
         _LOGGER.debug("Creating schedule with data: %s", schedule_data)
         try:
-            result = await self.hass.async_add_executor_job(
-                self.api.create_schedule, schedule_data
-            )
+            result = await self.api.create_schedule(schedule_data)
             if result is False:
                 raise ValueError("Schedule creation validation failed")
             _LOGGER.debug("Schedule creation result: %s", result)
@@ -196,9 +173,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise RuntimeError("Fellow Aiden library not initialized")
         _LOGGER.debug("Deleting schedule ID: %s", schedule_id)
         try:
-            result = await self.hass.async_add_executor_job(
-                self.api.delete_schedule_by_id, schedule_id
-            )
+            result = await self.api.delete_schedule_by_id(schedule_id)
             if result is False:
                 raise ValueError("Schedule deletion failed")
             _LOGGER.debug("Schedule deletion result: %s", result)
@@ -214,9 +189,7 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise RuntimeError("Fellow Aiden library not initialized")
         _LOGGER.debug("Toggling schedule ID: %s, enabled: %s", schedule_id, enabled)
         try:
-            result = await self.hass.async_add_executor_job(
-                self.api.toggle_schedule, schedule_id, enabled
-            )
+            result = await self.api.toggle_schedule(schedule_id, enabled)
             if result is False:
                 raise ValueError("Schedule toggle failed")
             _LOGGER.debug("Schedule toggle result: %s", result)

--- a/custom_components/fellow/fellow_aiden/__init__.py
+++ b/custom_components/fellow/fellow_aiden/__init__.py
@@ -1,6 +1,7 @@
 """Async Fellow object to interact with Aiden brewer."""
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from difflib import SequenceMatcher
@@ -104,6 +105,7 @@ class FellowAiden:
             if response.status not in self._RETRY_STATUSES or attempt == self._MAX_RETRIES:
                 return response
             response.release()
+            await asyncio.sleep(min(2 ** attempt, 8))
             self._log.debug(
                 "Retry %d/%d for %s %s (status %s)",
                 attempt + 1,
@@ -406,6 +408,8 @@ class FellowAiden:
         await self._ensure_success(response, "Profile creation")
 
         parsed = await self._parse_response(response)
+        if not isinstance(parsed, dict):
+            raise Exception(f"Unexpected profile creation payload: {parsed}")
         if "id" not in parsed:
             raise Exception(f"Error in processing: {parsed}")
 
@@ -476,6 +480,7 @@ class FellowAiden:
         self._log.debug(delete_url)
         response = await self._request_with_reauth("delete", delete_url)
         await self._ensure_success(response, f"Profile deletion ({pid})")
+        self._profiles = None
 
         self._log.debug("Profile deleted")
         return True
@@ -535,6 +540,7 @@ class FellowAiden:
         self._log.debug(delete_url)
         response = await self._request_with_reauth("delete", delete_url)
         await self._ensure_success(response, f"Schedule deletion ({sid})")
+        self._schedules = None
 
         self._log.debug("Schedule deleted")
         return True
@@ -566,4 +572,5 @@ class FellowAiden:
             "patch", patch_url, json={"enabled": enabled}
         )
         await self._ensure_success(response, f"Schedule toggle ({sid})")
+        self._schedules = None
         return True

--- a/custom_components/fellow/fellow_aiden/__init__.py
+++ b/custom_components/fellow/fellow_aiden/__init__.py
@@ -341,7 +341,7 @@ class FellowAiden:
     async def _is_valid_schedule_id(self, sid: str) -> bool:
         """Check if a schedule ID is valid."""
         schedules = await self.get_schedules()
-        return any(sid == s["id"] for s in schedules)
+        return any(sid == str(s["id"]) for s in schedules)
 
     # -- Profile operations -------------------------------------------------
 
@@ -508,6 +508,8 @@ class FellowAiden:
         await self._ensure_success(response, "Schedule creation")
 
         parsed = await self._parse_response(response)
+        if not isinstance(parsed, dict):
+            raise Exception(f"Unexpected schedule creation payload: {parsed}")
         if "id" not in parsed:
             message = parsed.get("message", "Unable to get error message.")
             if "Profile could not be found" in message:

--- a/custom_components/fellow/fellow_aiden/__init__.py
+++ b/custom_components/fellow/fellow_aiden/__init__.py
@@ -130,13 +130,13 @@ class FellowAiden:
                     self._log.debug(
                         "Still 401 after token refresh, falling back to full re-login"
                     )
-                    await self._do_auth(fetch_device=False)
                     response.release()
+                    await self._do_auth(fetch_device=False)
                     response = await self._request(method, url, **kwargs)
             else:
                 self._log.debug("Token refresh failed, falling back to full re-login")
-                await self._do_auth(fetch_device=False)
                 response.release()
+                await self._do_auth(fetch_device=False)
                 response = await self._request(method, url, **kwargs)
             if response.status == 401:
                 self._log.warning(
@@ -369,6 +369,7 @@ class FellowAiden:
         shared_url = self.BASE_URL + self.API_SHARED_PROFILE.format(bid=brew_id)
         response = await self._request_with_reauth("get", shared_url)
         if response.status == 404:
+            response.release()
             raise ValueError(f"Failed to fetch profile (ID: {brew_id})")
 
         await self._ensure_success(

--- a/custom_components/fellow/fellow_aiden/__init__.py
+++ b/custom_components/fellow/fellow_aiden/__init__.py
@@ -1,187 +1,238 @@
-"""Fellow object to interact with Aiden brewer."""
+"""Async Fellow object to interact with Aiden brewer."""
+from __future__ import annotations
+
 import logging
 import re
-import requests
 from difflib import SequenceMatcher
+from typing import Any
+
+import aiohttp
+from pydantic import ValidationError
+
 from .profile import CoffeeProfile
 from .schedule import CoffeeSchedule
-from pydantic import ValidationError
-from urllib3.util import Retry
-from requests.adapters import HTTPAdapter
 
 
-def similar(a, b):
+def similar(a: str, b: str) -> float:
     return SequenceMatcher(None, a, b).ratio()
 
-    
+
 class FellowAuthError(Exception):
     """Raised when Fellow API authentication fails (bad credentials)."""
 
 
 class FellowAiden:
+    """Async Fellow object to interact with Aiden brewer.
 
-    """Fellow object to interact with Aiden brewer."""
+    Requires an ``aiohttp.ClientSession`` (e.g. from Home Assistant's
+    ``async_get_clientsession``).  Call :meth:`authenticate` after
+    construction to perform the initial login and device fetch.
+    """
 
     LOGGER_NAME = "custom_components.fellow.fellow_aiden.api"
-    INTERVAL = 0.5
-    BASE_URL = 'https://l8qtmnc692.execute-api.us-west-2.amazonaws.com/v1'
-    API_AUTH = '/auth/login'
-    API_AUTH_REFRESH = '/auth/refresh'
-    API_DEVICES = '/devices'
-    API_DEVICE = '/devices/{id}'
-    API_SCHEDULES = '/devices/{id}/schedules'
-    API_SCHEDULE = '/devices/{id}/schedules/{sid}'
-    API_PROFILES = '/devices/{id}/profiles'
-    API_PROFILE = '/devices/{id}/profiles/{pid}'
-    API_PROFILE_SHARE = '/devices/{id}/profiles/{pid}/share'
-    API_SHARED_PROFILE = '/shared/{bid}'
+    BASE_URL = "https://l8qtmnc692.execute-api.us-west-2.amazonaws.com/v1"
+    API_AUTH = "/auth/login"
+    API_AUTH_REFRESH = "/auth/refresh"
+    API_DEVICES = "/devices"
+    API_DEVICE = "/devices/{id}"
+    API_SCHEDULES = "/devices/{id}/schedules"
+    API_SCHEDULE = "/devices/{id}/schedules/{sid}"
+    API_PROFILES = "/devices/{id}/profiles"
+    API_PROFILE = "/devices/{id}/profiles/{pid}"
+    API_PROFILE_SHARE = "/devices/{id}/profiles/{pid}/share"
+    API_SHARED_PROFILE = "/shared/{bid}"
     HEADERS = {
-        'User-Agent': 'Fellow/5 CFNetwork/1568.300.101 Darwin/24.2.0'
+        "User-Agent": "Fellow/5 CFNetwork/1568.300.101 Darwin/24.2.0",
     }
     SERVER_SIDE_PROFILE_FIELDS = [
-        'id',
-        'createdAt',
-        'deletedAt',
-        'lastUsedTime',
-        'sharedFrom',
-        'isDefaultProfile',
-        'instantBrew',
-        'folder',
-        'duration',
-        'lastGBQuantity'
+        "id",
+        "createdAt",
+        "deletedAt",
+        "lastUsedTime",
+        "sharedFrom",
+        "isDefaultProfile",
+        "instantBrew",
+        "folder",
+        "duration",
+        "lastGBQuantity",
     ]
 
-    def __init__(self, email, password):
-        """Start of self."""
-        self._log = self._logger()
+    _RETRY_STATUSES = frozenset({408, 500, 501, 502, 503, 504})
+    _MAX_RETRIES = 3
+
+    def __init__(
+        self, email: str, password: str, session: aiohttp.ClientSession
+    ) -> None:
+        """Store credentials and session.  Call ``authenticate()`` to log in."""
+        self._log = logging.getLogger(self.LOGGER_NAME)
         self._auth = False
-        self._token = None
-        self._refresh = None
+        self._token: str | None = None
+        self._refresh_token: str | None = None
         self._email = email
         self._password = password
-        self._device_config = None
-        self._brewer_id = None
-        self._profiles = None
-        self._schedules = None
+        self._device_config: dict[str, Any] | None = None
+        self._brewer_id: str | None = None
+        self._profiles: list[dict[str, Any]] | None = None
+        self._schedules: list[dict[str, Any]] | None = None
+        self._session = session
 
-        # Create instance-level session so each FellowAiden instance maintains its own auth state
-        self._session = requests.Session()
-        retries = Retry(
-            total=3,
-            status_forcelist=[408, 500, 501, 502, 503, 504],
-        )
-        self._session.mount('https://', HTTPAdapter(max_retries=retries))
+    # -- HTTP helpers -------------------------------------------------------
 
-        self.__auth(fetch_device=True)
-        
-    def _logger(self):
-        """Create a logger to be used between processes.
+    def _build_headers(self, authenticated: bool = True) -> dict[str, str]:
+        """Return request headers, optionally including the Bearer token."""
+        headers = dict(self.HEADERS)
+        if authenticated and self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+        return headers
 
-        :returns: Logging instance.
-        """
-        return logging.getLogger(self.LOGGER_NAME)
-        
-    def _parse_response(self, response):
-        """Parse a response body as JSON, falling back to raw text."""
-        try:
-            return response.json()
-        except ValueError:
-            text = response.text.strip()
-            if text:
-                return {"raw": text}
-            return {}
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        authenticated: bool = True,
+        **kwargs: Any,
+    ) -> aiohttp.ClientResponse:
+        """HTTP request with automatic retries on server errors."""
+        headers = self._build_headers(authenticated)
 
-    def _ensure_success(self, response, action):
-        """Raise a descriptive error when a response is not HTTP 2xx."""
-        if 200 <= response.status_code < 300:
-            return
+        response: aiohttp.ClientResponse | None = None
+        for attempt in range(self._MAX_RETRIES + 1):
+            response = await self._session.request(
+                method, url, headers=headers, **kwargs
+            )
+            if response.status not in self._RETRY_STATUSES or attempt == self._MAX_RETRIES:
+                return response
+            self._log.debug(
+                "Retry %d/%d for %s %s (status %s)",
+                attempt + 1,
+                self._MAX_RETRIES,
+                method.upper(),
+                url,
+                response.status,
+            )
+        return response  # type: ignore[return-value]
 
-        parsed = self._parse_response(response)
-        raise Exception(f"{action} failed ({response.status_code}): {parsed}")
-
-    def _request_with_reauth(self, method, url, **kwargs):
+    async def _request_with_reauth(
+        self, method: str, url: str, **kwargs: Any
+    ) -> aiohttp.ClientResponse:
         """Send a request and retry once after refreshing auth on HTTP 401."""
-        response = self._session.request(method, url, **kwargs)
-        if response.status_code == 401:
+        response = await self._request(method, url, **kwargs)
+        if response.status == 401:
             self._log.debug("Token expired, attempting refresh")
-            refreshed = self.__refresh_auth()
+            refreshed = await self._refresh_auth()
             if refreshed:
                 self._log.debug("Token refresh successful")
-                response = self._session.request(method, url, **kwargs)
-                if response.status_code == 401:
-                    self._log.debug("Still 401 after token refresh, falling back to full re-login")
-                    self.__auth(fetch_device=False)
-                    response = self._session.request(method, url, **kwargs)
+                response = await self._request(method, url, **kwargs)
+                if response.status == 401:
+                    self._log.debug(
+                        "Still 401 after token refresh, falling back to full re-login"
+                    )
+                    await self._do_auth(fetch_device=False)
+                    response = await self._request(method, url, **kwargs)
             else:
                 self._log.debug("Token refresh failed, falling back to full re-login")
-                self.__auth(fetch_device=False)
-                response = self._session.request(method, url, **kwargs)
-            if response.status_code == 401:
+                await self._do_auth(fetch_device=False)
+                response = await self._request(method, url, **kwargs)
+            if response.status == 401:
                 self._log.warning(
                     "Still unauthorized after re-authentication — credentials may be invalid"
                 )
         return response
 
-    def __refresh_auth(self):
+    async def _parse_response(
+        self, response: aiohttp.ClientResponse
+    ) -> Any:
+        """Parse a response body as JSON, falling back to raw text."""
+        try:
+            return await response.json(content_type=None)
+        except (ValueError, aiohttp.ContentTypeError):
+            text = (await response.text()).strip()
+            if text:
+                return {"raw": text}
+            return {}
+
+    async def _ensure_success(
+        self, response: aiohttp.ClientResponse, action: str
+    ) -> None:
+        """Raise a descriptive error when a response is not HTTP 2xx."""
+        if 200 <= response.status < 300:
+            return
+        parsed = await self._parse_response(response)
+        raise Exception(f"{action} failed ({response.status}): {parsed}")
+
+    # -- Authentication -----------------------------------------------------
+
+    async def authenticate(self) -> None:
+        """Authenticate and fetch initial device data."""
+        await self._do_auth(fetch_device=True)
+
+    async def _refresh_auth(self) -> bool:
         """Attempt to refresh the access token using the stored refresh token.
 
         Returns True on success, False on any failure (allowing fallback to full login).
         """
-        if not self._refresh:
+        if not self._refresh_token:
             return False
         try:
             refresh_url = self.BASE_URL + self.API_AUTH_REFRESH
-            response = self._session.post(
+            response = await self._request(
+                "post",
                 refresh_url,
-                json={"refreshToken": self._refresh},
-                headers=self.HEADERS,
+                authenticated=False,
+                json={"refreshToken": self._refresh_token},
             )
         except Exception:
             self._log.debug("Refresh token request failed", exc_info=True)
             return False
-        else:
-            if response.status_code != 200:
-                self._log.debug("Refresh endpoint returned %s", response.status_code)
-                return False
-            parsed = self._parse_response(response)
-            if "accessToken" not in parsed:
-                self._log.debug("Refresh response missing accessToken")
-                return False
-            self._token = parsed["accessToken"]
-            if "refreshToken" in parsed:
-                self._refresh = parsed["refreshToken"]
-            self._session.headers.update({"Authorization": "Bearer " + self._token})
-            return True
 
-    def __auth(self, fetch_device=False):
+        if response.status != 200:
+            self._log.debug("Refresh endpoint returned %s", response.status)
+            return False
+        parsed = await self._parse_response(response)
+        if "accessToken" not in parsed:
+            self._log.debug("Refresh response missing accessToken")
+            return False
+        self._token = parsed["accessToken"]
+        if "refreshToken" in parsed:
+            self._refresh_token = parsed["refreshToken"]
+        return True
+
+    async def _do_auth(self, fetch_device: bool = False) -> None:
+        """Perform email/password authentication."""
         self._log.debug("Authenticating user")
-        auth = {"email": self._email, "password": self._password}
-        self._session.headers.update(self.HEADERS)
         login_url = self.BASE_URL + self.API_AUTH
-        response = self._session.post(login_url, json=auth, headers=self.HEADERS)
-        if response.status_code in (400, 401, 403):
+        auth_payload = {"email": self._email, "password": self._password}
+        response = await self._request(
+            "post", login_url, authenticated=False, json=auth_payload,
+        )
+        if response.status in (400, 401, 403):
             raise FellowAuthError("Email or password incorrect.")
 
-        self._ensure_success(response, "Authentication")
-        parsed = self._parse_response(response)
+        await self._ensure_success(response, "Authentication")
+        parsed = await self._parse_response(response)
         if "accessToken" not in parsed or "refreshToken" not in parsed:
             raise Exception(f"Authentication response missing tokens: {parsed}")
 
         self._log.debug("Authentication successful")
         self._token = parsed["accessToken"]
-        self._refresh = parsed["refreshToken"]
-        self._session.headers.update({"Authorization": "Bearer " + self._token})
+        self._refresh_token = parsed["refreshToken"]
         self._auth = True
         if fetch_device:
-            self.__device()
-        
-    def __device(self):
+            await self._fetch_device()
+
+    # -- Device & data fetching ---------------------------------------------
+
+    async def _fetch_device(self) -> None:
+        """Fetch device info from the API."""
         self._log.debug("Fetching device for account")
         device_url = self.BASE_URL + self.API_DEVICES
-        response = self._request_with_reauth("get", device_url, params={"dataType": "real"})
-        self._ensure_success(response, "Device fetch")
+        response = await self._request_with_reauth(
+            "get", device_url, params={"dataType": "real"}
+        )
+        await self._ensure_success(response, "Device fetch")
 
-        parsed = self._parse_response(response)
+        parsed = await self._parse_response(response)
         self._log.debug(parsed)
         if not isinstance(parsed, list):
             raise Exception(f"Unexpected device response payload: {parsed}")
@@ -194,287 +245,312 @@ class FellowAiden:
 
         brewer_id = first_device.get("id")
         if not brewer_id:
-            raise Exception(f"Device response missing required id field: {first_device}")
+            raise Exception(
+                f"Device response missing required id field: {first_device}"
+            )
 
         self._device_config = first_device
         self._brewer_id = brewer_id
-
         self._profiles = None
         self._schedules = None
 
-        self._log.debug("Brewer ID: %s" % self._brewer_id)
+        self._log.debug("Brewer ID: %s", self._brewer_id)
         self._log.debug("Device and profile information set")
 
-    @property
-    def profiles(self):
+    async def fetch_device(self) -> None:
+        """Public method to re-fetch device data from the cloud."""
+        await self._fetch_device()
+
+    async def get_profiles(self) -> list[dict[str, Any]]:
+        """Return profiles, fetching from API if not cached."""
         if self._profiles is None:
             self._log.debug("Fetching profiles")
-            profiles_url = self.BASE_URL + self.API_PROFILES.format(id=self._brewer_id)
-            response = self._request_with_reauth("get", profiles_url)
-            self._ensure_success(response, "Profile fetch")
+            profiles_url = self.BASE_URL + self.API_PROFILES.format(
+                id=self._brewer_id
+            )
+            response = await self._request_with_reauth("get", profiles_url)
+            await self._ensure_success(response, "Profile fetch")
 
-            parsed = self._parse_response(response)
+            parsed = await self._parse_response(response)
             if not isinstance(parsed, list):
                 raise Exception(f"Unexpected profiles response payload: {parsed}")
 
             self._log.debug(parsed)
             self._profiles = parsed
-        
         return self._profiles
-    
-    @property
-    def schedules(self):
+
+    async def get_schedules(self) -> list[dict[str, Any]]:
+        """Return schedules, fetching from API if not cached."""
         if self._schedules is None:
             self._log.debug("Fetching schedules")
-            schedules_url = self.BASE_URL + self.API_SCHEDULES.format(id=self._brewer_id)
-            response = self._request_with_reauth("get", schedules_url)
-            self._ensure_success(response, "Schedule fetch")
+            schedules_url = self.BASE_URL + self.API_SCHEDULES.format(
+                id=self._brewer_id
+            )
+            response = await self._request_with_reauth("get", schedules_url)
+            await self._ensure_success(response, "Schedule fetch")
 
-            parsed = self._parse_response(response)
+            parsed = await self._parse_response(response)
             if not isinstance(parsed, list):
                 raise Exception(f"Unexpected schedules response payload: {parsed}")
 
             self._log.debug(parsed)
             self._schedules = parsed
-        
         return self._schedules
 
+    def get_device_config(self) -> dict[str, Any] | None:
+        """Return the cached device config."""
+        return self._device_config
 
-    def __get_profile_ids(self):
-        """Return a list of profile IDs."""
-        return ["%s (%s)" % (profile["id"], profile["title"]) for profile in self.profiles]
-    
-    def __is_valid_profile_id(self, pid):
+    def get_display_name(self) -> str | None:
+        """Return the brewer display name from cached config."""
+        if self._device_config is None:
+            return None
+        return self._device_config.get("displayName")
+
+    def get_brewer_id(self) -> str | None:
+        """Return the brewer ID."""
+        return self._brewer_id
+
+    # -- Internal helpers ---------------------------------------------------
+
+    async def _get_profile_ids(self) -> list[str]:
+        """Return a list of profile IDs with titles."""
+        profiles = await self.get_profiles()
+        return [f"{p['id']} ({p['title']})" for p in profiles]
+
+    async def _is_valid_profile_id(self, pid: str) -> bool:
         """Check if a profile ID is valid."""
-        for profile in self.profiles:
-            if pid == profile["id"]:
-                return True
-        return False
-    
-    def __get_schedule_ids(self):
-        """Return a list of schedule IDs."""
-        return ["%s" % (schedule["id"]) for schedule in self.schedules]
-    
-    def __is_valid_schedule_id(self, sid):
-        """Check if a schedule ID is valid."""
-        for schedule in self.schedules:
-            if sid == schedule["id"]:
-                return True
-        return False
+        profiles = await self.get_profiles()
+        return any(pid == p["id"] for p in profiles)
 
-    def parse_brewlink_url(self, link):
+    async def _get_schedule_ids(self) -> list[str]:
+        """Return a list of schedule IDs."""
+        schedules = await self.get_schedules()
+        return [str(s["id"]) for s in schedules]
+
+    async def _is_valid_schedule_id(self, sid: str) -> bool:
+        """Check if a schedule ID is valid."""
+        schedules = await self.get_schedules()
+        return any(sid == s["id"] for s in schedules)
+
+    # -- Profile operations -------------------------------------------------
+
+    async def get_profile_by_title(
+        self, title: str, fuzzy: bool = False
+    ) -> dict[str, Any] | None:
+        """Find a profile by title."""
+        profiles = await self.get_profiles()
+        for profile in profiles:
+            if fuzzy and similar(profile["title"].lower(), title.lower()) > 0.65:
+                return profile
+            if profile["title"].lower() == title.lower():
+                return profile
+        return None
+
+    async def parse_brewlink_url(self, link: str) -> dict[str, Any]:
         """Extract profile information from a shared brew link."""
         self._log.debug("Parsing shared brew link")
-        pattern = r'(?:.*?/p/)?([a-zA-Z0-9]+)/?$'
+        pattern = r"(?:.*?/p/)?([a-zA-Z0-9]+)/?$"
         match = re.search(pattern, link)
         if not match:
             raise ValueError("Invalid profile URL or ID format")
         brew_id = match.group(1)
-        self._log.debug("Brew ID: %s" % brew_id)
+        self._log.debug("Brew ID: %s", brew_id)
         shared_url = self.BASE_URL + self.API_SHARED_PROFILE.format(bid=brew_id)
-        response = self._request_with_reauth("get", shared_url)
-        if response.status_code == 404:
+        response = await self._request_with_reauth("get", shared_url)
+        if response.status == 404:
             raise ValueError(f"Failed to fetch profile (ID: {brew_id})")
 
-        self._ensure_success(response, f"Shared profile fetch (ID: {brew_id})")
-        parsed = self._parse_response(response)
+        await self._ensure_success(
+            response, f"Shared profile fetch (ID: {brew_id})"
+        )
+        parsed = await self._parse_response(response)
         if not isinstance(parsed, dict):
-            raise ValueError(f"Unexpected shared profile payload for ID {brew_id}: {parsed}")
+            raise ValueError(
+                f"Unexpected shared profile payload for ID {brew_id}: {parsed}"
+            )
 
         for field in self.SERVER_SIDE_PROFILE_FIELDS:
             parsed.pop(field, None)
-        self._log.debug("Profile fetched: %s" % parsed)
+        self._log.debug("Profile fetched: %s", parsed)
         return parsed
-    
-    def get_device_config(self, remote=False):
-        """Return the current device config.
 
-        :param remote: If True, force a new request to Fellow's API
-                    to refresh the device config. Otherwise,
-                    returns the cached config.
-        """
-        if remote:
-            self.__device()
-        return self._device_config
-
-        
-    def get_display_name(self):
-        return self._device_config.get('displayName', None)
-        
-    def get_profiles(self):
-        return self.profiles
-    
-    def get_schedules(self):
-        return self.schedules
-    
-    def get_profile_by_title(self, title, fuzzy=False):
-        for profile in self.profiles:
-            if fuzzy:
-                if similar(profile['title'].lower(), title.lower()) > 0.65:
-                    return profile
-            if profile['title'].lower() == title.lower():
-                return profile
-        return None
-        
-    def get_brewer_id(self):
-        return self._brewer_id
-        
-    def create_profile(self, data):
-        self._log.debug("Checking brew profile: %s" % data)
+    async def create_profile(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Create a new brew profile."""
+        self._log.debug("Checking brew profile: %s", data)
         try:
             CoffeeProfile.model_validate(data)
         except ValidationError as err:
-            self._log.error("Brew profile format was invalid: %s" % err)
+            self._log.error("Brew profile format was invalid: %s", err)
             raise ValueError(f"Brew profile format was invalid: {err}") from err
-        
-        if 'id' in data.keys():
-            raise Exception("Candidate profiles must be free of server derived fields.")
+
+        if "id" in data:
+            raise Exception(
+                "Candidate profiles must be free of server derived fields."
+            )
 
         self._log.debug("Brew profile passed checks")
         profile_url = self.BASE_URL + self.API_PROFILES.format(id=self._brewer_id)
-        response = self._request_with_reauth("post", profile_url, json=data)
-        self._ensure_success(response, "Profile creation")
+        response = await self._request_with_reauth("post", profile_url, json=data)
+        await self._ensure_success(response, "Profile creation")
 
-        parsed = self._parse_response(response)
+        parsed = await self._parse_response(response)
         if "id" not in parsed:
-            raise Exception("Error in processing: %s" % parsed)
+            raise Exception(f"Error in processing: {parsed}")
 
-        self.__device()  # Refreshed profiles this way
-        self._log.debug("Brew profile created: %s" % parsed)
+        await self._fetch_device()
+        self._log.debug("Brew profile created: %s", parsed)
         return parsed
-    
-    def update_profile(self, profile_id, data):
+
+    async def update_profile(
+        self, profile_id: str, data: dict[str, Any]
+    ) -> bool:
         """Update an existing profile by ID."""
-        self._log.debug(f"Updating brew profile {profile_id}: {data}")
-        
-        # Validate the profile data
+        self._log.debug("Updating brew profile %s: %s", profile_id, data)
         try:
             CoffeeProfile.model_validate(data)
         except ValidationError as err:
-            self._log.error("Brew profile format was invalid: %s" % err)
+            self._log.error("Brew profile format was invalid: %s", err)
             raise ValueError(f"Brew profile format was invalid: {err}") from err
-        
-        # Check if profile exists
-        if not self.__is_valid_profile_id(profile_id):
-            message = f"Profile with ID {profile_id} does not exist. Valid profiles: {self.__get_profile_ids()}"
-            raise Exception(message)
-        
-        # Remove any server-side fields that might be in the data
+
+        if not await self._is_valid_profile_id(profile_id):
+            ids = await self._get_profile_ids()
+            raise Exception(
+                f"Profile with ID {profile_id} does not exist. Valid profiles: {ids}"
+            )
+
         for field in self.SERVER_SIDE_PROFILE_FIELDS:
-            if field in data:
-                data.pop(field, None)
-        
-        # Use PATCH to update the profile
-        update_url = self.BASE_URL + self.API_PROFILE.format(id=self._brewer_id, pid=profile_id)
-        self._log.debug(f"Update URL: {update_url}")
-        response = self._request_with_reauth("patch", update_url, json=data)
-        self._ensure_success(response, f"Profile update ({profile_id})")
-        
-        self.__device()  # Refresh profiles
-        self._log.debug(f"Profile {profile_id} updated successfully")
+            data.pop(field, None)
+
+        update_url = self.BASE_URL + self.API_PROFILE.format(
+            id=self._brewer_id, pid=profile_id
+        )
+        self._log.debug("Update URL: %s", update_url)
+        response = await self._request_with_reauth("patch", update_url, json=data)
+        await self._ensure_success(response, f"Profile update ({profile_id})")
+
+        await self._fetch_device()
+        self._log.debug("Profile %s updated successfully", profile_id)
         return True
-    
-    def create_schedule(self, data):
-        self._log.debug("Checking schedule: %s" % data)
-        try:
-            CoffeeSchedule.model_validate(data)
-        except ValidationError as err:
-            self._log.error("Brew schedule format was invalid: %s" % err)
-            raise ValueError(f"Brew schedule format was invalid: {err}") from err
-        
-        if 'id' in data.keys():
-            raise Exception("Candidate schedules must be free of server derived fields.")
 
-        self._log.debug("Brew schedule passed checks")
-        schedule_url = self.BASE_URL + self.API_SCHEDULES.format(id=self._brewer_id)
-        response = self._request_with_reauth("post", schedule_url, json=data)
-        self._ensure_success(response, "Schedule creation")
-
-        parsed = self._parse_response(response)
-        if "id" not in parsed:
-            message = parsed.get("message", "Unable to get error message.")
-            if "Profile could not be found" in message:
-                message += "Valid profiles: %s" % self.__get_profile_ids()
-            raise Exception("Error in processing: %s" % message)
-
-        self.__device()  # Refreshed schedules this way
-        self._log.debug("Brew schedule created: %s" % parsed)
-        return parsed
-
-    def create_profile_from_link(self, link):
+    async def create_profile_from_link(self, link: str) -> dict[str, Any]:
         """Create a profile from a shared brew link."""
         self._log.debug("Creating profile from link")
-        data = self.parse_brewlink_url(link)
-        return self.create_profile(data)
-    
-    def generate_share_link(self, pid):
+        data = await self.parse_brewlink_url(link)
+        return await self.create_profile(data)
+
+    async def generate_share_link(self, pid: str) -> str:
         """Generate a share link for a profile."""
         self._log.debug("Generating share link")
-        share_url = self.BASE_URL + self.API_PROFILE_SHARE.format(id=self._brewer_id, pid=pid)
-        self._log.debug("Share URL: %s" % share_url)
-        response = self._request_with_reauth("post", share_url)
-        self._ensure_success(response, f"Share link generation ({pid})")
+        share_url = self.BASE_URL + self.API_PROFILE_SHARE.format(
+            id=self._brewer_id, pid=pid
+        )
+        self._log.debug("Share URL: %s", share_url)
+        response = await self._request_with_reauth("post", share_url)
+        await self._ensure_success(response, f"Share link generation ({pid})")
 
-        parsed = self._parse_response(response)
+        parsed = await self._parse_response(response)
         if "link" not in parsed:
-            raise Exception("Error in processing: %s" % parsed)
+            raise Exception(f"Error in processing: {parsed}")
 
-        self._log.debug("Share link generated: %s" % parsed)
+        self._log.debug("Share link generated: %s", parsed)
         return parsed["link"]
-        
-    def delete_profile_by_id(self, pid):
+
+    async def delete_profile_by_id(self, pid: str) -> bool:
+        """Delete a profile by ID."""
         self._log.debug("Deleting profile")
-        # Check is too slow with new lazy loading impelementation
-        # if not self.__is_valid_profile_id(pid):
-        #     message = "Profile does not exist. Valid profiles: %s" % (self.__get_profile_ids())
-        #     raise Exception(message)
-        delete_url = self.BASE_URL + self.API_PROFILE.format(id=self._brewer_id, pid=pid)
+        delete_url = self.BASE_URL + self.API_PROFILE.format(
+            id=self._brewer_id, pid=pid
+        )
         self._log.debug(delete_url)
-        response = self._request_with_reauth("delete", delete_url)
-        self._ensure_success(response, f"Profile deletion ({pid})")
+        response = await self._request_with_reauth("delete", delete_url)
+        await self._ensure_success(response, f"Profile deletion ({pid})")
 
         self._log.debug("Profile deleted")
         return True
-    
-    def delete_schedule_by_id(self, sid):
+
+    # -- Schedule operations ------------------------------------------------
+
+    async def create_schedule(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Create a new brew schedule."""
+        self._log.debug("Checking schedule: %s", data)
+        try:
+            CoffeeSchedule.model_validate(data)
+        except ValidationError as err:
+            self._log.error("Brew schedule format was invalid: %s", err)
+            raise ValueError(
+                f"Brew schedule format was invalid: {err}"
+            ) from err
+
+        if "id" in data:
+            raise Exception(
+                "Candidate schedules must be free of server derived fields."
+            )
+
+        self._log.debug("Brew schedule passed checks")
+        schedule_url = self.BASE_URL + self.API_SCHEDULES.format(
+            id=self._brewer_id
+        )
+        response = await self._request_with_reauth(
+            "post", schedule_url, json=data
+        )
+        await self._ensure_success(response, "Schedule creation")
+
+        parsed = await self._parse_response(response)
+        if "id" not in parsed:
+            message = parsed.get("message", "Unable to get error message.")
+            if "Profile could not be found" in message:
+                ids = await self._get_profile_ids()
+                message += f"Valid profiles: {ids}"
+            raise Exception(f"Error in processing: {message}")
+
+        await self._fetch_device()
+        self._log.debug("Brew schedule created: %s", parsed)
+        return parsed
+
+    async def delete_schedule_by_id(self, sid: str) -> bool:
+        """Delete a schedule by ID."""
         self._log.debug("Deleting schedule")
-        if not self.__is_valid_schedule_id(sid):
-            message = "Schedule does not exist. Valid schedules: %s" % (self.__get_schedule_ids())
-            raise Exception(message)
-        delete_url = self.BASE_URL + self.API_SCHEDULE.format(id=self._brewer_id, sid=sid)
+        if not await self._is_valid_schedule_id(sid):
+            ids = await self._get_schedule_ids()
+            raise Exception(
+                f"Schedule does not exist. Valid schedules: {ids}"
+            )
+        delete_url = self.BASE_URL + self.API_SCHEDULE.format(
+            id=self._brewer_id, sid=sid
+        )
         self._log.debug(delete_url)
-        response = self._request_with_reauth("delete", delete_url)
-        self._ensure_success(response, f"Schedule deletion ({sid})")
+        response = await self._request_with_reauth("delete", delete_url)
+        await self._ensure_success(response, f"Schedule deletion ({sid})")
 
         self._log.debug("Schedule deleted")
         return True
-    
-    def adjust_setting(self, setting, value):
+
+    async def adjust_setting(self, setting: str, value: Any) -> bytes:
+        """Adjust a device setting."""
         patch_url = self.BASE_URL + self.API_DEVICE.format(id=self._brewer_id)
-        self._log.debug("Patch URL: %s" % patch_url)
-        response = self._request_with_reauth("patch", patch_url, json={setting: value})
-        self._ensure_success(response, f"Device setting update ({setting})")
-        return response.content
-    
-    def toggle_schedule(self, sid, enabled):
-        if not self.__is_valid_schedule_id(sid):
-            message = "Schedule does not exist. Valid schedules: %s" % (self.__get_schedule_ids())
-            raise Exception(message)
-        patch_url = self.BASE_URL + self.API_SCHEDULE.format(id=self._brewer_id, sid=sid)
-        self._log.debug("Patch URL: %s" % patch_url)
-        response = self._request_with_reauth("patch", patch_url, json={"enabled": enabled})
-        self._ensure_success(response, f"Schedule toggle ({sid})")
+        self._log.debug("Patch URL: %s", patch_url)
+        response = await self._request_with_reauth(
+            "patch", patch_url, json={setting: value}
+        )
+        await self._ensure_success(
+            response, f"Device setting update ({setting})"
+        )
+        return await response.read()
+
+    async def toggle_schedule(self, sid: str, enabled: bool) -> bool:
+        """Enable or disable a schedule."""
+        if not await self._is_valid_schedule_id(sid):
+            ids = await self._get_schedule_ids()
+            raise Exception(
+                f"Schedule does not exist. Valid schedules: {ids}"
+            )
+        patch_url = self.BASE_URL + self.API_SCHEDULE.format(
+            id=self._brewer_id, sid=sid
+        )
+        self._log.debug("Patch URL: %s", patch_url)
+        response = await self._request_with_reauth(
+            "patch", patch_url, json={"enabled": enabled}
+        )
+        await self._ensure_success(response, f"Schedule toggle ({sid})")
         return True
-        
-    def fetch_device(self):
-        """Public method to re-fetch device data from the cloud."""
-        self.__device()
-
-    def authenticate(self):
-        """Public method to reauthenticate the user.
-
-        This allows external callers (like HA integration) to trigger
-        reauthentication without accessing the private __auth method.
-        """
-        self._log.debug("Reauthenticating user via public method")
-        self.__auth(fetch_device=True)

--- a/custom_components/fellow/fellow_aiden/__init__.py
+++ b/custom_components/fellow/fellow_aiden/__init__.py
@@ -103,6 +103,7 @@ class FellowAiden:
             )
             if response.status not in self._RETRY_STATUSES or attempt == self._MAX_RETRIES:
                 return response
+            response.release()
             self._log.debug(
                 "Retry %d/%d for %s %s (status %s)",
                 attempt + 1,
@@ -123,19 +124,26 @@ class FellowAiden:
             refreshed = await self._refresh_auth()
             if refreshed:
                 self._log.debug("Token refresh successful")
+                response.release()
                 response = await self._request(method, url, **kwargs)
                 if response.status == 401:
                     self._log.debug(
                         "Still 401 after token refresh, falling back to full re-login"
                     )
                     await self._do_auth(fetch_device=False)
+                    response.release()
                     response = await self._request(method, url, **kwargs)
             else:
                 self._log.debug("Token refresh failed, falling back to full re-login")
                 await self._do_auth(fetch_device=False)
+                response.release()
                 response = await self._request(method, url, **kwargs)
             if response.status == 401:
                 self._log.warning(
+                    "Still unauthorized after re-authentication — credentials may be invalid"
+                )
+                response.release()
+                raise FellowAuthError(
                     "Still unauthorized after re-authentication — credentials may be invalid"
                 )
         return response
@@ -188,6 +196,7 @@ class FellowAiden:
 
         if response.status != 200:
             self._log.debug("Refresh endpoint returned %s", response.status)
+            response.release()
             return False
         parsed = await self._parse_response(response)
         if "accessToken" not in parsed:
@@ -207,6 +216,7 @@ class FellowAiden:
             "post", login_url, authenticated=False, json=auth_payload,
         )
         if response.status in (400, 401, 403):
+            response.release()
             raise FellowAuthError("Email or password incorrect.")
 
         await self._ensure_success(response, "Authentication")
@@ -501,7 +511,7 @@ class FellowAiden:
             message = parsed.get("message", "Unable to get error message.")
             if "Profile could not be found" in message:
                 ids = await self._get_profile_ids()
-                message += f"Valid profiles: {ids}"
+                message += f" Valid profiles: {ids}"
             raise Exception(f"Error in processing: {message}")
 
         await self._fetch_device()


### PR DESCRIPTION
The vendored library was synchronous. Every API call got wrapped in `async_add_executor_job` to avoid blocking the event loop. This rewrites it to use aiohttp natively.

- `fellow_aiden/__init__.py`: all methods are now coroutines, constructor no longer does I/O (call `await authenticate()` after), accepts an external `aiohttp.ClientSession`
- `coordinator.py`: removed the sync `_fetch()` bridge and all executor wrapping, calls the library directly with await
- `config_flow.py`:  `_try_login` is async, gets the HA-managed session via `async_get_clientsession`
- Retry logic for 408/5xx moved from urllib3's `Retry` adapter to a loop in `_request()`

The integration now shares HA's managed aiohttp session instead of creating its own `requests.Session`. This gets us closer to the HA quality scale's [`async-dependency`][1] and [`inject-websession`][2] rules.

[1]: https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/async-dependency
[2]: https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/inject-websession

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * All profile, schedule and device actions are now fully asynchronous; client accepts an injected HTTP session and requires explicit async authenticate() and explicit data-refresh calls.
  * Coordinator and history updates run inside the async flow for smoother background operation.

* **Bug Fixes**
  * Update failures are logged instead of crashing.
  * Token refresh with fallback re-login; retries now target server errors (408/5xx) for improved reliability.

* **Documentation**
  * Docs updated to reflect async startup, auth, and usage patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->