### PR TITLE
Handle mixed-device setup failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ automation:
 - No direct brew start: the Fellow API does not support starting a brew remotely. Use the physical controls or a schedule.
 - Profile selection is display-only: the dropdown shows profiles but selecting one does nothing.
 - Cloud-only: all data comes through Fellow's servers. If their API is down, the integration can't update.
-- Single device per entry: each config entry connects to one brewer. Multiple brewers on the same account are not supported.
-- Vendored library: the Fellow Aiden Python library is vendored from [9b/fellow-aiden](https://github.com/9b/fellow-aiden) and uses synchronous HTTP. The coordinator wraps calls in an executor thread.
+- Single device per entry: each config entry connects to one brewer. If an account contains multiple Fellow products, the integration auto-selects the first compatible Aiden brewer, but it still does not let you choose between multiple compatible Aidens on the same account.
+- Vendored client: the integration uses the vendored `custom_components/fellow/fellow_aiden/` client from this repository. It does not install or import a PyPI `fellow-aiden` package, and it talks directly to Fellow's AWS API endpoint rather than `app.fellow.com`.
 
 ---
 
@@ -236,7 +236,7 @@ automation:
 
 ## FAQ & Troubleshooting
 
-1. **"Device not found"** -- Make sure you have a Fellow Aiden brewer linked to the account you used during setup.
+1. **"Device not found" / "No supported brewer found"** -- Make sure the account you used has at least one Fellow Aiden brewer linked to it. Mixed-device accounts are supported by auto-selecting the first compatible Aiden. This integration uses Fellow's AWS API endpoint directly and does not call `app.fellow.com`.
 
 2. **Sensors showing "Unknown"** -- The brewer may not have reported data yet. Wait a few minutes. If it persists for days, file a bug report.
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ automation:
 - Profile selection is display-only: the dropdown shows profiles but selecting one does nothing.
 - Cloud-only: all data comes through Fellow's servers. If their API is down, the integration can't update.
 - Single device per entry: each config entry connects to one brewer. If an account contains multiple Fellow products, the integration auto-selects the first compatible Aiden brewer, but it still does not let you choose between multiple compatible Aidens on the same account.
-- Vendored client: the integration uses the vendored `custom_components/fellow/fellow_aiden/` client from this repository. It does not install or import a PyPI `fellow-aiden` package, and it talks directly to Fellow's AWS API endpoint rather than `app.fellow.com`.
 
 ---
 
@@ -236,7 +235,7 @@ automation:
 
 ## FAQ & Troubleshooting
 
-1. **"Device not found" / "No supported brewer found"** -- Make sure the account you used has at least one Fellow Aiden brewer linked to it. Mixed-device accounts are supported by auto-selecting the first compatible Aiden. This integration uses Fellow's AWS API endpoint directly and does not call `app.fellow.com`.
+1. **"Device not found" / "No supported brewer found"** -- Make sure the account you used has at least one Fellow Aiden brewer linked to it. Mixed-device accounts are supported by auto-selecting the first compatible Aiden.
 
 2. **Sensors showing "Unknown"** -- The brewer may not have reported data yet. Wait a few minutes. If it persists for days, file a bug report.
 

--- a/custom_components/fellow/config_flow.py
+++ b/custom_components/fellow/config_flow.py
@@ -12,7 +12,12 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import TextSelector, TextSelectorConfig, TextSelectorType
 
-from .fellow_aiden import FellowAiden
+from .fellow_aiden import (
+    FellowAiden,
+    FellowAuthError,
+    FellowConnectionError,
+    FellowNoSupportedDeviceError,
+)
 from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL_MINUTES, MIN_UPDATE_INTERVAL_SECONDS
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,6 +37,17 @@ async def _try_login(hass: HomeAssistant, email: str, password: str) -> None:
     await api.authenticate()
 
 
+def _login_error_key(err: Exception) -> str:
+    """Map a login/setup exception to a config flow error key."""
+    if isinstance(err, FellowAuthError):
+        return "auth"
+    if isinstance(err, FellowConnectionError):
+        return "cannot_connect"
+    if isinstance(err, FellowNoSupportedDeviceError):
+        return "unsupported_device"
+    return "unknown"
+
+
 class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Fellow Aiden."""
 
@@ -49,9 +65,12 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             password = user_input["password"]
             try:
                 await _try_login(self.hass, email, password)
-            except Exception:
-                _LOGGER.exception("Authentication failed")
-                errors["base"] = "auth"
+            except Exception as err:
+                errors["base"] = _login_error_key(err)
+                if errors["base"] == "unknown":
+                    _LOGGER.exception("Authentication failed")
+                else:
+                    _LOGGER.debug("Authentication failed: %s", err)
             else:
                 await self.async_set_unique_id(email.lower())
                 self._abort_if_unique_id_configured()
@@ -84,9 +103,12 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="unknown")
             try:
                 await _try_login(self.hass, self._reauth_email, password)
-            except Exception:
-                _LOGGER.exception("Re-authentication failed")
-                errors["base"] = "auth"
+            except Exception as err:
+                errors["base"] = _login_error_key(err)
+                if errors["base"] == "unknown":
+                    _LOGGER.exception("Re-authentication failed")
+                else:
+                    _LOGGER.debug("Re-authentication failed: %s", err)
             else:
                 await self.async_set_unique_id(self._reauth_email.lower())
                 self._abort_if_unique_id_mismatch(reason="wrong_account")
@@ -119,9 +141,12 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             password = user_input["password"]
             try:
                 await _try_login(self.hass, email, password)
-            except Exception:
-                _LOGGER.exception("Reconfigure authentication failed")
-                errors["base"] = "auth"
+            except Exception as err:
+                errors["base"] = _login_error_key(err)
+                if errors["base"] == "unknown":
+                    _LOGGER.exception("Reconfigure authentication failed")
+                else:
+                    _LOGGER.debug("Reconfigure authentication failed: %s", err)
             else:
                 await self.async_set_unique_id(email.lower())
                 self._abort_if_unique_id_mismatch(reason="wrong_account")

--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -7,11 +7,20 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+    ConfigEntryNotReady,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .fellow_aiden import FellowAiden, FellowAuthError
+from .fellow_aiden import (
+    FellowAiden,
+    FellowAuthError,
+    FellowConnectionError,
+    FellowNoSupportedDeviceError,
+)
 from .brew_history import BrewHistoryManager
 from .const import DEFAULT_UPDATE_INTERVAL_MINUTES
 
@@ -52,6 +61,12 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise ConfigEntryAuthFailed(
                 f"Authentication failed: {err}"
             ) from err
+        except FellowConnectionError as err:
+            raise ConfigEntryNotReady(
+                f"Unable to connect to Fellow cloud: {err}"
+            ) from err
+        except FellowNoSupportedDeviceError as err:
+            raise ConfigEntryError(str(err)) from err
         await super().async_config_entry_first_refresh()
 
     async def _async_update_data(self) -> dict[str, Any]:
@@ -68,6 +83,14 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise ConfigEntryAuthFailed(  # noqa: TRY003
                 f"Authentication failed: {err}"
             ) from err
+        except FellowConnectionError as err:
+            raise UpdateFailed(  # noqa: TRY003
+                f"Device fetch failed: {err}"
+            ) from err
+        except FellowNoSupportedDeviceError as err:
+            raise UpdateFailed(  # noqa: TRY003
+                f"Device fetch failed: {err}"
+            ) from err
         except Exception as err:
             raise UpdateFailed(  # noqa: TRY003
                 f"Device fetch failed: {err}"
@@ -81,6 +104,14 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except FellowAuthError as err:
             raise ConfigEntryAuthFailed(
                 f"Authentication failed: {err}"
+            ) from err
+        except FellowConnectionError as err:
+            raise UpdateFailed(  # noqa: TRY003
+                f"Data fetch failed: {err}"
+            ) from err
+        except FellowNoSupportedDeviceError as err:
+            raise UpdateFailed(  # noqa: TRY003
+                f"Data fetch failed: {err}"
             ) from err
         except Exception as err:
             raise UpdateFailed(  # noqa: TRY003

--- a/custom_components/fellow/fellow_aiden/__init__.py
+++ b/custom_components/fellow/fellow_aiden/__init__.py
@@ -126,8 +126,13 @@ class FellowAiden:
                 raise FellowConnectionError(
                     f"Request failed for {method.upper()} {url}: {err}"
                 ) from err
-            if response.status not in self._RETRY_STATUSES or attempt == self._MAX_RETRIES:
+            if response.status not in self._TRANSIENT_HTTP_STATUSES:
                 return response
+            if response.status not in self._RETRY_STATUSES or attempt == self._MAX_RETRIES:
+                parsed = await self._parse_response(response)
+                raise FellowConnectionError(
+                    f"Request failed for {method.upper()} {url} ({response.status}): {parsed}"
+                )
             response.release()
             await asyncio.sleep(min(2 ** attempt, 8))
             self._log.debug(

--- a/custom_components/fellow/fellow_aiden/__init__.py
+++ b/custom_components/fellow/fellow_aiden/__init__.py
@@ -372,7 +372,9 @@ class FellowAiden:
         await self._ensure_success(response, action)
 
         parsed = await self._parse_response(response)
-        if not isinstance(parsed, list):
+        if not isinstance(parsed, list) or any(
+            not isinstance(item, dict) for item in parsed
+        ):
             raise Exception(f"Unexpected {action.lower()} payload: {parsed}")
 
         self._log.debug(parsed)
@@ -409,6 +411,10 @@ class FellowAiden:
         if not isinstance(parsed, list):
             raise _IncompatibleDeviceError(
                 f"Device {brewer_id} returned non-list {action.lower()} payload: {parsed}"
+            )
+        if any(not isinstance(item, dict) for item in parsed):
+            raise _IncompatibleDeviceError(
+                f"Device {brewer_id} returned invalid {action.lower()} payload: {parsed}"
             )
         return parsed
 

--- a/custom_components/fellow/fellow_aiden/__init__.py
+++ b/custom_components/fellow/fellow_aiden/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import ssl
 from difflib import SequenceMatcher
 from typing import Any
 
@@ -20,6 +21,18 @@ def similar(a: str, b: str) -> float:
 
 class FellowAuthError(Exception):
     """Raised when Fellow API authentication fails (bad credentials)."""
+
+
+class FellowConnectionError(Exception):
+    """Raised when a Fellow API request fails due to connectivity issues."""
+
+
+class FellowNoSupportedDeviceError(Exception):
+    """Raised when the account has no compatible Fellow Aiden brewer."""
+
+
+class _IncompatibleDeviceError(Exception):
+    """Raised when a device candidate does not expose Aiden endpoints."""
 
 
 class FellowAiden:
@@ -59,6 +72,8 @@ class FellowAiden:
     ]
 
     _RETRY_STATUSES = frozenset({408, 500, 501, 502, 503, 504})
+    _TRANSIENT_HTTP_STATUSES = frozenset({408, 429, 500, 501, 502, 503, 504})
+    _INCOMPATIBLE_DEVICE_STATUSES = frozenset({400, 404, 405, 422})
     _MAX_RETRIES = 3
 
     def __init__(
@@ -99,9 +114,18 @@ class FellowAiden:
 
         response: aiohttp.ClientResponse | None = None
         for attempt in range(self._MAX_RETRIES + 1):
-            response = await self._session.request(
-                method, url, headers=headers, **kwargs
-            )
+            try:
+                response = await self._session.request(
+                    method, url, headers=headers, **kwargs
+                )
+            except (
+                aiohttp.ClientError,
+                asyncio.TimeoutError,
+                ssl.SSLError,
+            ) as err:
+                raise FellowConnectionError(
+                    f"Request failed for {method.upper()} {url}: {err}"
+                ) from err
             if response.status not in self._RETRY_STATUSES or attempt == self._MAX_RETRIES:
                 return response
             response.release()
@@ -248,26 +272,33 @@ class FellowAiden:
         self._log.debug(parsed)
         if not isinstance(parsed, list):
             raise Exception(f"Unexpected device response payload: {parsed}")
-        if not parsed:
-            raise Exception("No Fellow Aiden devices found for this account.")
-
-        first_device = parsed[0]
-        if not isinstance(first_device, dict):
-            raise Exception(f"Unexpected device payload type: {first_device}")
-
-        brewer_id = first_device.get("id")
-        if not brewer_id:
-            raise Exception(
-                f"Device response missing required id field: {first_device}"
+        device_candidates = [
+            device for device in parsed if isinstance(device, dict)
+        ]
+        if not device_candidates:
+            raise FellowNoSupportedDeviceError(
+                "No supported Fellow Aiden brewer was found on this account."
             )
 
-        self._device_config = first_device
-        self._brewer_id = brewer_id
-        self._profiles = None
-        self._schedules = None
+        for candidate in self._ordered_device_candidates(device_candidates):
+            try:
+                brewer_id, profiles, schedules = await self._probe_device(candidate)
+            except _IncompatibleDeviceError as err:
+                self._log.debug("Skipping incompatible device candidate: %s", err)
+                continue
 
-        self._log.debug("Brewer ID: %s", self._brewer_id)
-        self._log.debug("Device and profile information set")
+            self._device_config = candidate
+            self._brewer_id = brewer_id
+            self._profiles = profiles
+            self._schedules = schedules
+
+            self._log.debug("Brewer ID: %s", self._brewer_id)
+            self._log.debug("Device and profile information set")
+            return
+
+        raise FellowNoSupportedDeviceError(
+            "No supported Fellow Aiden brewer was found on this account."
+        )
 
     async def fetch_device(self) -> None:
         """Public method to re-fetch device data from the cloud."""
@@ -280,15 +311,9 @@ class FellowAiden:
             profiles_url = self.BASE_URL + self.API_PROFILES.format(
                 id=self._brewer_id
             )
-            response = await self._request_with_reauth("get", profiles_url)
-            await self._ensure_success(response, "Profile fetch")
-
-            parsed = await self._parse_response(response)
-            if not isinstance(parsed, list):
-                raise Exception(f"Unexpected profiles response payload: {parsed}")
-
-            self._log.debug(parsed)
-            self._profiles = parsed
+            self._profiles = await self._fetch_list_resource(
+                profiles_url, "Profile fetch"
+            )
         return self._profiles
 
     async def get_schedules(self) -> list[dict[str, Any]]:
@@ -298,15 +323,9 @@ class FellowAiden:
             schedules_url = self.BASE_URL + self.API_SCHEDULES.format(
                 id=self._brewer_id
             )
-            response = await self._request_with_reauth("get", schedules_url)
-            await self._ensure_success(response, "Schedule fetch")
-
-            parsed = await self._parse_response(response)
-            if not isinstance(parsed, list):
-                raise Exception(f"Unexpected schedules response payload: {parsed}")
-
-            self._log.debug(parsed)
-            self._schedules = parsed
+            self._schedules = await self._fetch_list_resource(
+                schedules_url, "Schedule fetch"
+            )
         return self._schedules
 
     def get_device_config(self) -> dict[str, Any] | None:
@@ -324,6 +343,89 @@ class FellowAiden:
         return self._brewer_id
 
     # -- Internal helpers ---------------------------------------------------
+
+    def _ordered_device_candidates(
+        self, devices: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Return devices ordered with the cached brewer first when possible."""
+        if not self._brewer_id:
+            return devices
+
+        preferred = [
+            device for device in devices if device.get("id") == self._brewer_id
+        ]
+        remaining = [
+            device for device in devices if device.get("id") != self._brewer_id
+        ]
+        return preferred + remaining
+
+    async def _fetch_list_resource(
+        self, url: str, action: str
+    ) -> list[dict[str, Any]]:
+        """Fetch a list payload from the Fellow API."""
+        response = await self._request_with_reauth("get", url)
+        await self._ensure_success(response, action)
+
+        parsed = await self._parse_response(response)
+        if not isinstance(parsed, list):
+            raise Exception(f"Unexpected {action.lower()} payload: {parsed}")
+
+        self._log.debug(parsed)
+        return parsed
+
+    async def _probe_list_resource(
+        self, brewer_id: str, url: str, action: str
+    ) -> list[dict[str, Any]]:
+        """Probe a candidate device endpoint and treat non-Aiden shapes as incompatible."""
+        response = await self._request_with_reauth("get", url)
+
+        if response.status in (401, 403):
+            parsed = await self._parse_response(response)
+            raise FellowAuthError(
+                f"{action} unauthorized for device {brewer_id} ({response.status}): {parsed}"
+            )
+        if response.status in self._TRANSIENT_HTTP_STATUSES:
+            parsed = await self._parse_response(response)
+            raise FellowConnectionError(
+                f"{action} failed for device {brewer_id} ({response.status}): {parsed}"
+            )
+        if response.status in self._INCOMPATIBLE_DEVICE_STATUSES:
+            response.release()
+            raise _IncompatibleDeviceError(
+                f"Device {brewer_id} does not support {action.lower()} ({response.status})"
+            )
+        if not 200 <= response.status < 300:
+            parsed = await self._parse_response(response)
+            raise _IncompatibleDeviceError(
+                f"Device {brewer_id} returned {response.status} for {action.lower()}: {parsed}"
+            )
+
+        parsed = await self._parse_response(response)
+        if not isinstance(parsed, list):
+            raise _IncompatibleDeviceError(
+                f"Device {brewer_id} returned non-list {action.lower()} payload: {parsed}"
+            )
+        return parsed
+
+    async def _probe_device(
+        self, candidate: dict[str, Any]
+    ) -> tuple[str, list[dict[str, Any]], list[dict[str, Any]]]:
+        """Return cached data for a compatible Aiden candidate."""
+        brewer_id = candidate.get("id")
+        if not isinstance(brewer_id, str) or not brewer_id:
+            raise _IncompatibleDeviceError(
+                f"Device response missing required id field: {candidate}"
+            )
+
+        profiles_url = self.BASE_URL + self.API_PROFILES.format(id=brewer_id)
+        schedules_url = self.BASE_URL + self.API_SCHEDULES.format(id=brewer_id)
+        profiles = await self._probe_list_resource(
+            brewer_id, profiles_url, "Profile fetch"
+        )
+        schedules = await self._probe_list_resource(
+            brewer_id, schedules_url, "Schedule fetch"
+        )
+        return brewer_id, profiles, schedules
 
     async def _get_profile_ids(self) -> list[str]:
         """Return a list of profile IDs with titles."""

--- a/custom_components/fellow/fellow_aiden/__init__.py
+++ b/custom_components/fellow/fellow_aiden/__init__.py
@@ -393,6 +393,7 @@ class FellowAiden:
             )
         if response.status in self._TRANSIENT_HTTP_STATUSES:
             parsed = await self._parse_response(response)
+            response.release()
             raise FellowConnectionError(
                 f"{action} failed for device {brewer_id} ({response.status}): {parsed}"
             )
@@ -403,6 +404,7 @@ class FellowAiden:
             )
         if not 200 <= response.status < 300:
             parsed = await self._parse_response(response)
+            response.release()
             raise _IncompatibleDeviceError(
                 f"Device {brewer_id} returned {response.status} for {action.lower()}: {parsed}"
             )

--- a/custom_components/fellow/strings.json
+++ b/custom_components/fellow/strings.json
@@ -39,6 +39,7 @@
     "error": {
       "auth": "Invalid email or password.",
       "cannot_connect": "Could not connect to Fellow servers. Try again later.",
+      "unsupported_device": "No supported Fellow Aiden brewer was found on this account.",
       "unknown": "An unexpected error occurred."
     },
     "abort": {

--- a/custom_components/fellow/translations/en.json
+++ b/custom_components/fellow/translations/en.json
@@ -39,6 +39,7 @@
     "error": {
       "auth": "Invalid email or password.",
       "cannot_connect": "Could not connect to Fellow servers. Try again later.",
+      "unsupported_device": "No supported Fellow Aiden brewer was found on this account.",
       "unknown": "An unexpected error occurred."
     },
     "abort": {

--- a/custom_components/fellow/translations/es.json
+++ b/custom_components/fellow/translations/es.json
@@ -11,7 +11,10 @@
       }
     },
     "error": {
-      "auth": "Correo electrónico o contraseña incorrectos"
+      "auth": "Correo electrónico o contraseña incorrectos.",
+      "cannot_connect": "No se pudo conectar con los servidores de Fellow. Inténtalo de nuevo más tarde.",
+      "unsupported_device": "No se encontró ninguna cafetera Fellow Aiden compatible en esta cuenta.",
+      "unknown": "Ocurrió un error inesperado."
     }
   },
   "options": {

--- a/tests/module_loader.py
+++ b/tests/module_loader.py
@@ -7,18 +7,27 @@ from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
-
-
-def _clear_modules() -> None:
-    prefixes = (
-        "custom_components",
-        "homeassistant",
+_OWNED_EXACT_MODULES = frozenset(
+    {
         "aiohttp",
         "pydantic",
         "voluptuous",
-    )
+        "homeassistant",
+        "homeassistant.config_entries",
+        "homeassistant.core",
+        "homeassistant.helpers",
+        "homeassistant.helpers.aiohttp_client",
+        "homeassistant.helpers.selector",
+        "custom_components.fellow",
+    }
+)
+
+
+def _clear_modules() -> None:
     for name in list(sys.modules):
-        if name.startswith(prefixes):
+        if name in _OWNED_EXACT_MODULES or name.startswith(
+            "custom_components.fellow."
+        ):
             sys.modules.pop(name, None)
 
 

--- a/tests/module_loader.py
+++ b/tests/module_loader.py
@@ -4,7 +4,7 @@ import importlib.util
 import sys
 import types
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 ROOT = Path(__file__).resolve().parents[1]
 _OWNED_EXACT_MODULES = frozenset(
@@ -18,9 +18,35 @@ _OWNED_EXACT_MODULES = frozenset(
         "homeassistant.helpers",
         "homeassistant.helpers.aiohttp_client",
         "homeassistant.helpers.selector",
+        "custom_components",
         "custom_components.fellow",
     }
 )
+
+_MISSING = object()
+
+
+def _owned_module_names() -> list[str]:
+    names = set(_OWNED_EXACT_MODULES)
+    names.update(
+        name for name in sys.modules if name.startswith("custom_components.fellow.")
+    )
+    return list(names)
+
+
+def _snapshot_modules() -> dict[str, object]:
+    return {name: sys.modules.get(name, _MISSING) for name in _owned_module_names()}
+
+
+def _restore_modules(snapshot: dict[str, object]) -> None:
+    for name in _owned_module_names():
+        if name not in snapshot:
+            sys.modules.pop(name, None)
+    for name, original in snapshot.items():
+        if original is _MISSING:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original  # type: ignore[assignment]
 
 
 def _clear_modules() -> None:
@@ -270,7 +296,8 @@ def _load_module(
     return module
 
 
-def load_fellow_aiden_module() -> types.ModuleType:
+def load_fellow_aiden_module() -> tuple[types.ModuleType, Callable[[], None]]:
+    snapshot = _snapshot_modules()
     _clear_modules()
     _install_aiohttp_stub()
     _install_pydantic_stub()
@@ -279,14 +306,16 @@ def load_fellow_aiden_module() -> types.ModuleType:
         "custom_components.fellow.const",
         ROOT / "custom_components" / "fellow" / "const.py",
     )
-    return _load_module(
+    module = _load_module(
         "custom_components.fellow.fellow_aiden",
         ROOT / "custom_components" / "fellow" / "fellow_aiden" / "__init__.py",
         package=True,
     )
+    return module, lambda: _restore_modules(snapshot)
 
 
-def load_config_flow_module() -> types.ModuleType:
+def load_config_flow_module() -> tuple[types.ModuleType, Callable[[], None]]:
+    snapshot = _snapshot_modules()
     _clear_modules()
     _install_aiohttp_stub()
     _install_pydantic_stub()
@@ -302,7 +331,8 @@ def load_config_flow_module() -> types.ModuleType:
         ROOT / "custom_components" / "fellow" / "fellow_aiden" / "__init__.py",
         package=True,
     )
-    return _load_module(
+    module = _load_module(
         "custom_components.fellow.config_flow",
         ROOT / "custom_components" / "fellow" / "config_flow.py",
     )
+    return module, lambda: _restore_modules(snapshot)

--- a/tests/module_loader.py
+++ b/tests/module_loader.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _clear_modules() -> None:
+    prefixes = (
+        "custom_components",
+        "homeassistant",
+        "aiohttp",
+        "pydantic",
+        "voluptuous",
+    )
+    for name in list(sys.modules):
+        if name.startswith(prefixes):
+            sys.modules.pop(name, None)
+
+
+def _install_aiohttp_stub() -> None:
+    aiohttp = types.ModuleType("aiohttp")
+
+    class ClientError(Exception):
+        pass
+
+    class ContentTypeError(Exception):
+        pass
+
+    class ClientSession:
+        pass
+
+    class ClientResponse:
+        pass
+
+    aiohttp.ClientError = ClientError
+    aiohttp.ContentTypeError = ContentTypeError
+    aiohttp.ClientSession = ClientSession
+    aiohttp.ClientResponse = ClientResponse
+    sys.modules["aiohttp"] = aiohttp
+
+
+def _install_pydantic_stub() -> None:
+    pydantic = types.ModuleType("pydantic")
+
+    class ValidationError(Exception):
+        pass
+
+    class BaseModel:
+        @classmethod
+        def model_validate(cls, data: Any) -> Any:
+            return data
+
+    def field_validator(*_args: Any, **_kwargs: Any):
+        def decorator(func: Any) -> Any:
+            return func
+
+        return decorator
+
+    pydantic.BaseModel = BaseModel
+    pydantic.ValidationError = ValidationError
+    pydantic.field_validator = field_validator
+    sys.modules["pydantic"] = pydantic
+
+
+def _install_voluptuous_stub() -> None:
+    voluptuous = types.ModuleType("voluptuous")
+
+    class Invalid(Exception):
+        pass
+
+    def Schema(value: Any) -> Any:
+        return value
+
+    def Required(key: Any, default: Any = None) -> Any:
+        return key
+
+    def Optional(key: Any, default: Any = None) -> Any:
+        return key
+
+    def All(*validators: Any) -> tuple[Any, ...]:
+        return validators
+
+    def Coerce(value_type: type[Any]) -> Any:
+        return value_type
+
+    def Range(**_kwargs: Any) -> Any:
+        return lambda value: value
+
+    voluptuous.All = All
+    voluptuous.Coerce = Coerce
+    voluptuous.Invalid = Invalid
+    voluptuous.Optional = Optional
+    voluptuous.Range = Range
+    voluptuous.Required = Required
+    voluptuous.Schema = Schema
+    sys.modules["voluptuous"] = voluptuous
+
+
+def _install_homeassistant_stubs() -> None:
+    homeassistant = types.ModuleType("homeassistant")
+    homeassistant.__path__ = [str(ROOT / "tests" / "_homeassistant_stub")]
+    sys.modules["homeassistant"] = homeassistant
+
+    config_entries = types.ModuleType("homeassistant.config_entries")
+
+    class ConfigFlow:
+        def __init_subclass__(cls, **kwargs: Any) -> None:
+            kwargs.pop("domain", None)
+            super().__init_subclass__()
+
+        def __init__(self) -> None:
+            self.hass = None
+
+        async def async_set_unique_id(self, value: str) -> None:
+            self._unique_id = value
+
+        def _abort_if_unique_id_configured(self) -> None:
+            return None
+
+        def _abort_if_unique_id_mismatch(self, reason: str | None = None) -> None:
+            return None
+
+        def _get_reauth_entry(self) -> dict[str, Any]:
+            return {"entry_id": "reauth"}
+
+        def _get_reconfigure_entry(self) -> dict[str, Any]:
+            return {"entry_id": "reconfigure"}
+
+        def async_show_form(
+            self,
+            *,
+            step_id: str,
+            data_schema: Any = None,
+            errors: dict[str, str] | None = None,
+            last_step: bool = False,
+        ) -> dict[str, Any]:
+            return {
+                "type": "form",
+                "step_id": step_id,
+                "data_schema": data_schema,
+                "errors": errors or {},
+                "last_step": last_step,
+            }
+
+        def async_create_entry(self, *, title: str, data: dict[str, Any]) -> dict[str, Any]:
+            return {"type": "create_entry", "title": title, "data": data}
+
+        def async_abort(self, *, reason: str) -> dict[str, Any]:
+            return {"type": "abort", "reason": reason}
+
+        def async_update_reload_and_abort(
+            self, entry: Any, *, data_updates: dict[str, Any]
+        ) -> dict[str, Any]:
+            return {
+                "type": "abort",
+                "reason": "updated",
+                "entry": entry,
+                "data_updates": data_updates,
+            }
+
+    class OptionsFlow:
+        def __init__(self) -> None:
+            self.config_entry = types.SimpleNamespace(options={})
+
+        def async_create_entry(self, *, title: str, data: dict[str, Any]) -> dict[str, Any]:
+            return {"type": "create_entry", "title": title, "data": data}
+
+        def async_show_form(
+            self,
+            *,
+            step_id: str,
+            data_schema: Any = None,
+            errors: dict[str, str] | None = None,
+            last_step: bool = False,
+        ) -> dict[str, Any]:
+            return {
+                "type": "form",
+                "step_id": step_id,
+                "data_schema": data_schema,
+                "errors": errors or {},
+                "last_step": last_step,
+            }
+
+    config_entries.ConfigEntry = type("ConfigEntry", (), {})
+    config_entries.ConfigFlow = ConfigFlow
+    config_entries.ConfigFlowResult = dict
+    config_entries.OptionsFlow = OptionsFlow
+    sys.modules["homeassistant.config_entries"] = config_entries
+
+    core = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:
+        pass
+
+    def callback(func: Any) -> Any:
+        return func
+
+    core.HomeAssistant = HomeAssistant
+    core.callback = callback
+    sys.modules["homeassistant.core"] = core
+
+    aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
+
+    def async_get_clientsession(hass: Any) -> Any:
+        return getattr(hass, "session", None)
+
+    aiohttp_client.async_get_clientsession = async_get_clientsession
+    sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client
+
+    selector = types.ModuleType("homeassistant.helpers.selector")
+
+    class TextSelector:
+        def __init__(self, config: Any) -> None:
+            self.config = config
+
+    class TextSelectorConfig:
+        def __init__(self, *, type: str) -> None:
+            self.type = type
+
+    class TextSelectorType:
+        EMAIL = "email"
+        PASSWORD = "password"
+
+    selector.TextSelector = TextSelector
+    selector.TextSelectorConfig = TextSelectorConfig
+    selector.TextSelectorType = TextSelectorType
+    sys.modules["homeassistant.helpers.selector"] = selector
+
+    helpers = types.ModuleType("homeassistant.helpers")
+    helpers.__path__ = [str(ROOT / "tests" / "_homeassistant_helpers_stub")]
+    sys.modules["homeassistant.helpers"] = helpers
+
+
+def _install_package_placeholders() -> None:
+    custom_components = types.ModuleType("custom_components")
+    custom_components.__path__ = [str(ROOT / "custom_components")]
+    sys.modules["custom_components"] = custom_components
+
+    fellow = types.ModuleType("custom_components.fellow")
+    fellow.__path__ = [str(ROOT / "custom_components" / "fellow")]
+    sys.modules["custom_components.fellow"] = fellow
+
+
+def _load_module(
+    name: str, path: Path, *, package: bool = False
+) -> types.ModuleType:
+    kwargs: dict[str, Any] = {}
+    if package:
+        kwargs["submodule_search_locations"] = [str(path.parent)]
+    spec = importlib.util.spec_from_file_location(name, path, **kwargs)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_fellow_aiden_module() -> types.ModuleType:
+    _clear_modules()
+    _install_aiohttp_stub()
+    _install_pydantic_stub()
+    _install_package_placeholders()
+    _load_module(
+        "custom_components.fellow.const",
+        ROOT / "custom_components" / "fellow" / "const.py",
+    )
+    return _load_module(
+        "custom_components.fellow.fellow_aiden",
+        ROOT / "custom_components" / "fellow" / "fellow_aiden" / "__init__.py",
+        package=True,
+    )
+
+
+def load_config_flow_module() -> types.ModuleType:
+    _clear_modules()
+    _install_aiohttp_stub()
+    _install_pydantic_stub()
+    _install_voluptuous_stub()
+    _install_homeassistant_stubs()
+    _install_package_placeholders()
+    _load_module(
+        "custom_components.fellow.const",
+        ROOT / "custom_components" / "fellow" / "const.py",
+    )
+    _load_module(
+        "custom_components.fellow.fellow_aiden",
+        ROOT / "custom_components" / "fellow" / "fellow_aiden" / "__init__.py",
+        package=True,
+    )
+    return _load_module(
+        "custom_components.fellow.config_flow",
+        ROOT / "custom_components" / "fellow" / "config_flow.py",
+    )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,7 +9,8 @@ from module_loader import load_config_flow_module
 
 class ConfigFlowErrorMappingTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
-        self.module = load_config_flow_module()
+        self.module, cleanup = load_config_flow_module()
+        self.addCleanup(cleanup)
 
     async def test_async_step_user_maps_known_login_errors(self) -> None:
         cases = [

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -20,6 +20,7 @@ class ConfigFlowErrorMappingTests(unittest.IsolatedAsyncioTestCase):
                 self.module.FellowNoSupportedDeviceError("no brewer"),
                 "unsupported_device",
             ),
+            (RuntimeError("unexpected"), "unknown"),
         ]
 
         for error, expected in cases:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import types
 import unittest
+from unittest.mock import patch
 
 from module_loader import load_config_flow_module
 
@@ -27,13 +28,15 @@ class ConfigFlowErrorMappingTests(unittest.IsolatedAsyncioTestCase):
                 del hass, email, password
                 raise exc
 
-            self.module._try_login = failing_login
-            flow = self.module.FellowAidenConfigFlow()
-            flow.hass = types.SimpleNamespace(session=object())
+            with self.subTest(expected=expected), patch.object(
+                self.module, "_try_login", new=failing_login
+            ):
+                flow = self.module.FellowAidenConfigFlow()
+                flow.hass = types.SimpleNamespace(session=object())
 
-            result = await flow.async_step_user(
-                {"email": "user@example.com", "password": "secret"}
-            )
+                result = await flow.async_step_user(
+                    {"email": "user@example.com", "password": "secret"}
+                )
 
-            self.assertEqual(result["type"], "form")
-            self.assertEqual(result["errors"]["base"], expected)
+                self.assertEqual(result["type"], "form")
+                self.assertEqual(result["errors"]["base"], expected)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import types
+import unittest
+
+from module_loader import load_config_flow_module
+
+
+class ConfigFlowErrorMappingTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.module = load_config_flow_module()
+
+    async def test_async_step_user_maps_known_login_errors(self) -> None:
+        cases = [
+            (self.module.FellowAuthError("bad creds"), "auth"),
+            (self.module.FellowConnectionError("offline"), "cannot_connect"),
+            (
+                self.module.FellowNoSupportedDeviceError("no brewer"),
+                "unsupported_device",
+            ),
+        ]
+
+        for error, expected in cases:
+            async def failing_login(
+                hass: object, email: str, password: str, *, exc: Exception = error
+            ) -> None:
+                del hass, email, password
+                raise exc
+
+            self.module._try_login = failing_login
+            flow = self.module.FellowAidenConfigFlow()
+            flow.hass = types.SimpleNamespace(session=object())
+
+            result = await flow.async_step_user(
+                {"email": "user@example.com", "password": "secret"}
+            )
+
+            self.assertEqual(result["type"], "form")
+            self.assertEqual(result["errors"]["base"], expected)

--- a/tests/test_fellow_aiden.py
+++ b/tests/test_fellow_aiden.py
@@ -50,7 +50,8 @@ class FakeSession:
 
 class FellowAidenDiscoveryTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
-        self.module = load_fellow_aiden_module()
+        self.module, cleanup = load_fellow_aiden_module()
+        self.addCleanup(cleanup)
         self.base_url = self.module.FellowAiden.BASE_URL
 
     def _api(self, responses: dict[tuple[str, str], list[object]]):

--- a/tests/test_fellow_aiden.py
+++ b/tests/test_fellow_aiden.py
@@ -167,6 +167,25 @@ class FellowAidenDiscoveryTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(self.module.FellowConnectionError):
             await api.authenticate()
 
+    async def test_raises_connection_error_after_final_transient_login_status(self) -> None:
+        login_url = f"{self.base_url}/auth/login"
+        api, session = self._api(
+            {
+                ("post", login_url): [
+                    FakeResponse(503, {"message": "Service unavailable"})
+                    for _ in range(self.module.FellowAiden._MAX_RETRIES + 1)
+                ]
+            }
+        )
+
+        with self.assertRaises(self.module.FellowConnectionError):
+            await api.authenticate()
+
+        self.assertEqual(
+            session.requests,
+            [("post", login_url)] * (self.module.FellowAiden._MAX_RETRIES + 1),
+        )
+
     async def test_reuses_cached_brewer_when_it_remains_compatible(self) -> None:
         api, session = self._api(
             {
@@ -210,13 +229,10 @@ class FellowAidenDiscoveryTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(api.get_brewer_id(), "aiden-2")
         self.assertEqual(
-            session.requests[1:3],
+            session.requests,
             [
+                ("get", f"{self.base_url}/devices"),
                 ("get", f"{self.base_url}/devices/aiden-2/profiles"),
                 ("get", f"{self.base_url}/devices/aiden-2/schedules"),
             ],
-        )
-        self.assertNotIn(
-            ("get", f"{self.base_url}/devices/aiden-1/profiles"),
-            session.requests,
         )

--- a/tests/test_fellow_aiden.py
+++ b/tests/test_fellow_aiden.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from module_loader import load_fellow_aiden_module
+
+
+class FakeResponse:
+    def __init__(self, status: int, payload: object) -> None:
+        self.status = status
+        self._payload = payload
+        self.released = False
+
+    async def json(self, content_type: object = None) -> object:
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+    async def text(self) -> str:
+        return str(self._payload)
+
+    async def read(self) -> bytes:
+        return str(self._payload).encode()
+
+    def release(self) -> None:
+        self.released = True
+
+
+class FakeSession:
+    def __init__(self, responses: dict[tuple[str, str], list[object]]) -> None:
+        self._responses = {
+            key: list(value)
+            for key, value in responses.items()
+        }
+        self.requests: list[tuple[str, str]] = []
+
+    async def request(self, method: str, url: str, headers: object = None, **kwargs: object) -> object:
+        del headers, kwargs
+        key = (method.lower(), url)
+        self.requests.append(key)
+        queue = self._responses.get(key)
+        if not queue:
+            raise AssertionError(f"Unexpected request: {key}")
+        result = queue.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+class FellowAidenDiscoveryTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.module = load_fellow_aiden_module()
+        self.base_url = self.module.FellowAiden.BASE_URL
+
+    def _api(self, responses: dict[tuple[str, str], list[object]]):
+        session = FakeSession(responses)
+        api = self.module.FellowAiden("user@example.com", "secret", session)
+        return api, session
+
+    async def test_selects_first_compatible_aiden_after_skipping_incompatible_device(self) -> None:
+        api, _session = self._api(
+            {
+                ("post", f"{self.base_url}/auth/login"): [
+                    FakeResponse(200, {"accessToken": "token", "refreshToken": "refresh"})
+                ],
+                ("get", f"{self.base_url}/devices"): [
+                    FakeResponse(
+                        200,
+                        [
+                            {"id": "espresso-1", "displayName": "Espresso"},
+                            {"id": "aiden-1", "displayName": "Aiden"},
+                        ],
+                    )
+                ],
+                ("get", f"{self.base_url}/devices/espresso-1/profiles"): [
+                    FakeResponse(404, {"message": "Not found"})
+                ],
+                ("get", f"{self.base_url}/devices/aiden-1/profiles"): [
+                    FakeResponse(200, [])
+                ],
+                ("get", f"{self.base_url}/devices/aiden-1/schedules"): [
+                    FakeResponse(200, [])
+                ],
+            }
+        )
+
+        await api.authenticate()
+
+        self.assertEqual(api.get_brewer_id(), "aiden-1")
+        self.assertEqual(api.get_display_name(), "Aiden")
+        self.assertEqual(await api.get_profiles(), [])
+        self.assertEqual(await api.get_schedules(), [])
+
+    async def test_empty_profiles_and_schedules_are_valid_for_supported_device(self) -> None:
+        api, _session = self._api(
+            {
+                ("post", f"{self.base_url}/auth/login"): [
+                    FakeResponse(200, {"accessToken": "token", "refreshToken": "refresh"})
+                ],
+                ("get", f"{self.base_url}/devices"): [
+                    FakeResponse(200, [{"id": "aiden-1", "displayName": "Aiden"}])
+                ],
+                ("get", f"{self.base_url}/devices/aiden-1/profiles"): [
+                    FakeResponse(200, [])
+                ],
+                ("get", f"{self.base_url}/devices/aiden-1/schedules"): [
+                    FakeResponse(200, [])
+                ],
+            }
+        )
+
+        await api.authenticate()
+
+        self.assertEqual(await api.get_profiles(), [])
+        self.assertEqual(await api.get_schedules(), [])
+
+    async def test_raises_when_no_supported_devices_are_found(self) -> None:
+        api, _session = self._api(
+            {
+                ("post", f"{self.base_url}/auth/login"): [
+                    FakeResponse(200, {"accessToken": "token", "refreshToken": "refresh"})
+                ],
+                ("get", f"{self.base_url}/devices"): [
+                    FakeResponse(
+                        200,
+                        [
+                            {"id": "espresso-1", "displayName": "Espresso"},
+                            {"id": "unknown-1", "displayName": "Other"},
+                        ],
+                    )
+                ],
+                ("get", f"{self.base_url}/devices/espresso-1/profiles"): [
+                    FakeResponse(404, {"message": "Not found"})
+                ],
+                ("get", f"{self.base_url}/devices/unknown-1/profiles"): [
+                    FakeResponse(200, {"message": "wrong shape"})
+                ],
+            }
+        )
+
+        with self.assertRaises(self.module.FellowNoSupportedDeviceError):
+            await api.authenticate()
+
+    async def test_wraps_login_network_failures_as_connection_errors(self) -> None:
+        api, _session = self._api(
+            {
+                ("post", f"{self.base_url}/auth/login"): [
+                    self.module.aiohttp.ClientError("network down")
+                ]
+            }
+        )
+
+        with self.assertRaises(self.module.FellowConnectionError):
+            await api.authenticate()
+
+    async def test_wraps_discovery_timeouts_as_connection_errors(self) -> None:
+        api, _session = self._api(
+            {
+                ("post", f"{self.base_url}/auth/login"): [
+                    FakeResponse(200, {"accessToken": "token", "refreshToken": "refresh"})
+                ],
+                ("get", f"{self.base_url}/devices"): [asyncio.TimeoutError()],
+            }
+        )
+
+        with self.assertRaises(self.module.FellowConnectionError):
+            await api.authenticate()
+
+    async def test_reuses_cached_brewer_when_it_remains_compatible(self) -> None:
+        api, session = self._api(
+            {
+                ("post", f"{self.base_url}/auth/login"): [
+                    FakeResponse(200, {"accessToken": "token", "refreshToken": "refresh"})
+                ],
+                ("get", f"{self.base_url}/devices"): [
+                    FakeResponse(
+                        200,
+                        [
+                            {"id": "espresso-1", "displayName": "Espresso"},
+                            {"id": "aiden-2", "displayName": "Second Aiden"},
+                        ],
+                    ),
+                    FakeResponse(
+                        200,
+                        [
+                            {"id": "aiden-1", "displayName": "First Aiden"},
+                            {"id": "aiden-2", "displayName": "Second Aiden"},
+                        ],
+                    ),
+                ],
+                ("get", f"{self.base_url}/devices/espresso-1/profiles"): [
+                    FakeResponse(404, {"message": "Not found"})
+                ],
+                ("get", f"{self.base_url}/devices/aiden-2/profiles"): [
+                    FakeResponse(200, []),
+                    FakeResponse(200, []),
+                ],
+                ("get", f"{self.base_url}/devices/aiden-2/schedules"): [
+                    FakeResponse(200, []),
+                    FakeResponse(200, []),
+                ],
+            }
+        )
+
+        await api.authenticate()
+        session.requests.clear()
+
+        await api.fetch_device()
+
+        self.assertEqual(api.get_brewer_id(), "aiden-2")
+        self.assertEqual(
+            session.requests[1:3],
+            [
+                ("get", f"{self.base_url}/devices/aiden-2/profiles"),
+                ("get", f"{self.base_url}/devices/aiden-2/schedules"),
+            ],
+        )
+        self.assertNotIn(
+            ("get", f"{self.base_url}/devices/aiden-1/profiles"),
+            session.requests,
+        )


### PR DESCRIPTION
## Summary
- probe account devices until a compatible Aiden is found instead of assuming the first device is supported
- classify connection and unsupported-device setup failures separately from auth failures
- add regression tests for device discovery and config-flow error mapping

## Testing
- python3 -m unittest discover -s tests -v
- python3 -m compileall custom_components tests

Ref #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Multi-device Fellow accounts supported: integration now auto-selects the first compatible Aiden brewer when multiple products are linked (users still cannot choose between compatible devices)

* **Bug Fixes**
  - Improved setup/reauth error messaging: combined “Device not found” / “No supported brewer found” and clearer connection/unsupported-device reporting

* **Documentation**
  - Updated Known Limitations and FAQ to reflect auto-selection behavior

* **Tests**
  - Added unit tests for discovery, selection, retry and error-mapping scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->