### PR TITLE
Support multiple Aiden brewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Choose one of the following methods to install the **Fellow Aiden** integration:
 |-----------|-------------|
 | **Email** | The email address for your Fellow Aiden account. |
 | **Password** | Your Fellow account password. |
+| **Brewer** | The Aiden to add when the account contains more than one unconfigured brewer. |
+
+Each Aiden is represented by its own Home Assistant config entry. To add
+multiple brewers from the same Fellow account, run **Add Integration** once for
+each brewer and choose a different brewer each time. Already configured
+brewers are omitted from the chooser.
 
 ### Options
 
@@ -175,6 +181,10 @@ The **Fellow Aiden** coffee brewer. No other Fellow products are supported.
 | `fellow.debug_water_usage` | Dump raw water usage records. |
 | `fellow.refresh_and_log_data` | Force a data refresh and return the API response. |
 
+Service actions continue to work without a target when only one Fellow Aiden
+entry is loaded. With multiple brewers, choose the **Brewer** config entry (or
+provide `config_entry_id` in YAML) so the action cannot affect the wrong Aiden.
+
 ---
 
 ## Automation examples
@@ -220,7 +230,6 @@ automation:
 - No direct brew start: the Fellow API does not support starting a brew remotely. Use the physical controls or a schedule.
 - Profile selection is display-only: the dropdown shows profiles but selecting one does nothing.
 - Cloud-only: all data comes through Fellow's servers. If their API is down, the integration can't update.
-- Single device per entry: each config entry connects to one brewer. If an account contains multiple Fellow products, the integration auto-selects the first compatible Aiden brewer, but it still does not let you choose between multiple compatible Aidens on the same account.
 
 ---
 
@@ -235,7 +244,7 @@ automation:
 
 ## FAQ & Troubleshooting
 
-1. **"Device not found" / "No supported brewer found"** -- Make sure the account you used has at least one Fellow Aiden brewer linked to it. Mixed-device accounts are supported by auto-selecting the first compatible Aiden.
+1. **"Device not found" / "No supported brewer found"** -- Make sure the account you used has at least one Fellow Aiden brewer linked to it. Mixed-device and multi-Aiden accounts are supported; unsupported Fellow products are omitted from the brewer chooser.
 
 2. **Sensors showing "Unknown"** -- The brewer may not have reported data yet. Wait a few minutes. If it persists for days, file a bug report.
 

--- a/custom_components/fellow/__init__.py
+++ b/custom_components/fellow/__init__.py
@@ -146,11 +146,6 @@ def _get_coordinator(
         for entry in entries
         if entry.state is ConfigEntryState.LOADED
     ]
-    if not loaded_entries:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="not_loaded",
-        )
 
     if config_entry_id:
         target = next(
@@ -169,10 +164,19 @@ def _get_coordinator(
             )
         return target.runtime_data
 
-    if len(loaded_entries) > 1:
+    # Ambiguity is judged from every configured entry, not just the loaded
+    # ones: with a second brewer configured but temporarily unloaded, an
+    # untargeted call would otherwise silently act on the wrong Aiden.
+    if len(entries) > 1:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="target_required",
+        )
+
+    if not loaded_entries:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="not_loaded",
         )
 
     return loaded_entries[0].runtime_data
@@ -552,6 +556,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: FellowAidenConfigEntry) 
     if "brewer_id" not in entry.data and coordinator.api:
         brewer_id = coordinator.api.get_brewer_id()
         if brewer_id:
+            # Pin the already-constructed client too, so the entry stays on
+            # this brewer until the next reload instead of only preferring it.
+            coordinator.brewer_id = brewer_id
+            coordinator.api.pin_brewer(brewer_id)
             hass.config_entries.async_update_entry(
                 entry,
                 data={**entry.data, "brewer_id": brewer_id},

--- a/custom_components/fellow/__init__.py
+++ b/custom_components/fellow/__init__.py
@@ -7,6 +7,8 @@ import re
 from datetime import time
 from typing import cast
 
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import (
@@ -15,13 +17,10 @@ from homeassistant.core import (
     ServiceResponse,
     SupportsResponse,
 )
-import voluptuous as vol
-
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, PLATFORMS, DEFAULT_PROFILE_TYPE, FellowAidenConfigEntry
+from .const import DEFAULT_PROFILE_TYPE, DOMAIN, PLATFORMS, FellowAidenConfigEntry
 from .coordinator import FellowAidenDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -86,6 +85,8 @@ def _coerce_temperature_list(value: object) -> list[float]:
     for item in raw_items:
         if item == "":
             raise vol.Invalid("Temperature list contains empty values")
+        if isinstance(item, bool) or not isinstance(item, (str, int, float)):
+            raise vol.Invalid(f"Invalid temperature value: {item}")
         try:
             temperatures.append(float(item))
         except (TypeError, ValueError) as exc:
@@ -94,6 +95,7 @@ def _coerce_temperature_list(value: object) -> list[float]:
     return temperatures
 
 CREATE_PROFILE_SCHEMA = vol.All(_normalize_keys, vol.Schema({
+    vol.Optional("config_entry_id"): cv.string,
     vol.Optional("profile_type", default=DEFAULT_PROFILE_TYPE): vol.Coerce(int),
     vol.Required("title"): cv.string,
     vol.Required("ratio"): vol.Coerce(float),
@@ -112,6 +114,7 @@ CREATE_PROFILE_SCHEMA = vol.All(_normalize_keys, vol.Schema({
 }))
 
 CREATE_SCHEDULE_SCHEMA = vol.All(_normalize_keys, vol.Schema({
+    vol.Optional("config_entry_id"): cv.string,
     vol.Optional("monday", default=False): cv.boolean,
     vol.Optional("tuesday", default=False): cv.boolean,
     vol.Optional("wednesday", default=False): cv.boolean,
@@ -127,14 +130,10 @@ CREATE_SCHEDULE_SCHEMA = vol.All(_normalize_keys, vol.Schema({
 }))
 
 
-def _get_coordinator(hass: HomeAssistant) -> FellowAidenDataUpdateCoordinator:
-    """Return the coordinator for the first loaded config entry.
-
-    When multiple entries are loaded, service calls target the first loaded
-    entry and a warning is logged.
-
-    Raises ServiceValidationError when no entry is available or loaded.
-    """
+def _get_coordinator(
+    hass: HomeAssistant, config_entry_id: str | None = None
+) -> FellowAidenDataUpdateCoordinator:
+    """Return the coordinator selected for a service call."""
     entries = hass.config_entries.async_entries(DOMAIN)
     if not entries:
         raise ServiceValidationError(
@@ -153,13 +152,27 @@ def _get_coordinator(hass: HomeAssistant) -> FellowAidenDataUpdateCoordinator:
             translation_key="not_loaded",
         )
 
+    if config_entry_id:
+        target = next(
+            (
+                entry
+                for entry in loaded_entries
+                if entry.entry_id == config_entry_id
+            ),
+            None,
+        )
+        if target is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="target_not_loaded",
+                translation_placeholders={"config_entry_id": config_entry_id},
+            )
+        return target.runtime_data
+
     if len(loaded_entries) > 1:
-        loaded_entry_ids = ", ".join(entry.entry_id for entry in loaded_entries)
-        _LOGGER.warning(
-            "Multiple loaded %s entries detected (%s); using first loaded entry %s for service call",
-            DOMAIN,
-            loaded_entry_ids,
-            loaded_entries[0].entry_id,
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="target_required",
         )
 
     return loaded_entries[0].runtime_data
@@ -191,7 +204,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Register Fellow Aiden services."""
 
     async def handle_create_profile(call: ServiceCall) -> None:
-        coordinator = _get_coordinator(hass)
+        coordinator = _get_coordinator(
+            hass, call.data.get("config_entry_id")
+        )
         data = {
             "profileType": call.data.get("profile_type", DEFAULT_PROFILE_TYPE),
             "title": call.data["title"],
@@ -225,7 +240,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             ) from exc
 
     async def handle_delete_profile(call: ServiceCall) -> None:
-        coordinator = _get_coordinator(hass)
+        coordinator = _get_coordinator(
+            hass, call.data.get("config_entry_id")
+        )
         pid = call.data.get("profile_id")
         if not pid:
             raise ServiceValidationError(
@@ -242,7 +259,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             ) from exc
 
     async def handle_list_profiles(call: ServiceCall) -> ServiceResponse:
-        coordinator = _get_coordinator(hass)
+        coordinator = _get_coordinator(
+            hass, call.data.get("config_entry_id")
+        )
         data = coordinator.data
         if not data or "profiles" not in data or not data["profiles"]:
             return {"profiles": []}
@@ -265,7 +284,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 translation_key="provide_profile_id_or_name",
             )
 
-        coordinator = _get_coordinator(hass)
+        coordinator = _get_coordinator(
+            hass, call.data.get("config_entry_id")
+        )
         data = coordinator.data
         if not data or "profiles" not in data:
             raise ServiceValidationError(
@@ -294,7 +315,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         return {"profile": target}
 
     async def handle_create_schedule(call: ServiceCall) -> None:
-        coordinator = _get_coordinator(hass)
+        coordinator = _get_coordinator(
+            hass, call.data.get("config_entry_id")
+        )
         profile_input = call.data.get("profile_name") or call.data.get("profile_id")
         if not profile_input:
             raise ServiceValidationError(
@@ -364,7 +387,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             ) from exc
 
     async def handle_delete_schedule(call: ServiceCall) -> None:
-        coordinator = _get_coordinator(hass)
+        coordinator = _get_coordinator(
+            hass, call.data.get("config_entry_id")
+        )
         sid = call.data.get("schedule_id")
         if not sid:
             raise ServiceValidationError(
@@ -381,7 +406,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             ) from exc
 
     async def handle_toggle_schedule(call: ServiceCall) -> None:
-        coordinator = _get_coordinator(hass)
+        coordinator = _get_coordinator(
+            hass, call.data.get("config_entry_id")
+        )
         sid = call.data.get("schedule_id")
         if not sid:
             raise ServiceValidationError(
@@ -399,14 +426,18 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             ) from exc
 
     async def handle_list_schedules(call: ServiceCall) -> ServiceResponse:
-        coordinator = _get_coordinator(hass)
+        coordinator = _get_coordinator(
+            hass, call.data.get("config_entry_id")
+        )
         await coordinator.async_request_refresh()
         data = coordinator.data
         schedules = data.get("schedules", []) if data else []
         return {"schedules": schedules}
 
     async def handle_debug_water_usage(call: ServiceCall) -> ServiceResponse:
-        coordinator = _get_coordinator(hass)
+        coordinator = _get_coordinator(
+            hass, call.data.get("config_entry_id")
+        )
         device_config = (coordinator.data or {}).get("device_config", {})
         return {
             "water_usage_record_count": coordinator.history_manager.get_water_usage_count(),
@@ -417,7 +448,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         }
 
     async def handle_reset_water_tracking(call: ServiceCall) -> None:
-        coordinator = _get_coordinator(hass)
+        coordinator = _get_coordinator(
+            hass, call.data.get("config_entry_id")
+        )
         device_config = (coordinator.data or {}).get("device_config", {})
         current_total = device_config.get("totalWaterVolumeL", 0)
         _LOGGER.info(
@@ -435,7 +468,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             ) from exc
 
     async def handle_refresh_and_log_data(call: ServiceCall) -> ServiceResponse:
-        coordinator = _get_coordinator(hass)
+        coordinator = _get_coordinator(
+            hass, call.data.get("config_entry_id")
+        )
         coordinator._next_refresh_verbose = True
         await coordinator.async_request_refresh()
         data = coordinator.data
@@ -503,9 +538,26 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: FellowAidenConfigEntry) -> bool:
     """Set up Fellow Aiden from a config entry."""
     coordinator = FellowAidenDataUpdateCoordinator(
-        hass, entry, entry.data["email"], entry.data["password"]
+        hass,
+        entry,
+        entry.data["email"],
+        entry.data["password"],
+        entry.data.get("brewer_id"),
     )
     await coordinator.async_config_entry_first_refresh()
+
+    # Version 1 entries were keyed by account email. Persist the selected
+    # physical brewer so subsequent entries on the same account can choose a
+    # different Aiden and every poll remains pinned to the same device.
+    if "brewer_id" not in entry.data and coordinator.api:
+        brewer_id = coordinator.api.get_brewer_id()
+        if brewer_id:
+            hass.config_entries.async_update_entry(
+                entry,
+                data={**entry.data, "brewer_id": brewer_id},
+                unique_id=brewer_id,
+            )
+
     entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -516,6 +568,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: FellowAidenConfigEntry) 
 async def async_unload_entry(hass: HomeAssistant, entry: FellowAidenConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, entry: FellowAidenConfigEntry
+) -> bool:
+    """Migrate account-level entries to the per-brewer config format."""
+    if entry.version > 2:
+        return False
+    if entry.version == 1:
+        hass.config_entries.async_update_entry(entry, version=2)
+    return True
 
 
 async def _async_update_options(hass: HomeAssistant, entry: FellowAidenConfigEntry) -> None:

--- a/custom_components/fellow/config_flow.py
+++ b/custom_components/fellow/config_flow.py
@@ -271,6 +271,14 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     _LOGGER.debug("Reconfigure authentication failed: %s", err)
             else:
+                if not brewer_id:
+                    # A migrated entry that has not persisted its brewer yet is
+                    # still keyed by account email, so keep the original
+                    # account check as a fallback. Without it, reconfigure
+                    # would accept any Fellow account and silently retarget
+                    # the entry at a different physical brewer.
+                    await self.async_set_unique_id(email.lower())
+                    self._abort_if_unique_id_mismatch(reason="wrong_account")
                 return self.async_update_reload_and_abort(
                     entry,
                     data_updates={"email": email, "password": password},

--- a/custom_components/fellow/config_flow.py
+++ b/custom_components/fellow/config_flow.py
@@ -1,24 +1,28 @@
 """Config flow for Fellow Aiden."""
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
-from typing import Any, Mapping
+from typing import Any
 
 import voluptuous as vol
-
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.selector import TextSelector, TextSelectorConfig, TextSelectorType
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 
+from .const import DEFAULT_UPDATE_INTERVAL_MINUTES, DOMAIN, MIN_UPDATE_INTERVAL_SECONDS
 from .fellow_aiden import (
     FellowAiden,
     FellowAuthError,
     FellowConnectionError,
     FellowNoSupportedDeviceError,
 )
-from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL_MINUTES, MIN_UPDATE_INTERVAL_SECONDS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,11 +34,14 @@ USER_SCHEMA = vol.Schema(
 )
 
 
-async def _try_login(hass: HomeAssistant, email: str, password: str) -> None:
-    """Attempt to authenticate asynchronously. Raises on failure."""
+async def _try_login(
+    hass: HomeAssistant, email: str, password: str
+) -> list[dict[str, Any]]:
+    """Authenticate and return every supported brewer on the account."""
     session = async_get_clientsession(hass)
     api = FellowAiden(email, password, session)
-    await api.authenticate()
+    await api.authenticate(fetch_device=False)
+    return await api.get_supported_devices()
 
 
 def _login_error_key(err: Exception) -> str:
@@ -51,9 +58,65 @@ def _login_error_key(err: Exception) -> str:
 class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Fellow Aiden."""
 
-    VERSION = 1
+    VERSION = 2
 
     _reauth_email: str | None = None
+    _reauth_brewer_id: str | None = None
+    _email: str | None = None
+    _password: str | None = None
+    _available_devices: list[dict[str, Any]] | None = None
+
+    def _configured_brewer_ids(self) -> set[str]:
+        """Return brewer IDs already represented by config entries."""
+        brewer_ids: set[str] = set()
+        for entry in self._async_current_entries():
+            brewer_id = entry.data.get("brewer_id")
+            if not brewer_id:
+                runtime_data = getattr(entry, "runtime_data", None)
+                api = getattr(runtime_data, "api", None)
+                brewer_id = api.get_brewer_id() if api else None
+            if (
+                not brewer_id
+                and self._email
+                and self._available_devices
+                and entry.data.get("email", "").lower() == self._email.lower()
+            ):
+                # A not-yet-loaded version 1 entry has no persisted brewer ID.
+                # It used the first compatible device, so reserve that device
+                # until setup can migrate the entry.
+                brewer_id = self._available_devices[0].get("id")
+            if isinstance(brewer_id, str):
+                brewer_ids.add(brewer_id)
+        return brewer_ids
+
+    @staticmethod
+    def _device_name(device: Mapping[str, Any]) -> str:
+        """Return a useful display name for a discovered brewer."""
+        display_name = device.get("displayName")
+        if isinstance(display_name, str) and display_name:
+            return display_name
+        return f"Fellow Aiden ({device.get('id', 'unknown')})"
+
+    async def _async_create_device_entry(
+        self, device: dict[str, Any]
+    ) -> ConfigFlowResult:
+        """Create a config entry for one physical brewer."""
+        if self._email is None or self._password is None:
+            return self.async_abort(reason="unknown")
+
+        brewer_id = device.get("id")
+        if not isinstance(brewer_id, str):
+            return self.async_abort(reason="unknown")
+        await self.async_set_unique_id(brewer_id)
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=self._device_name(device),
+            data={
+                "email": self._email,
+                "password": self._password,
+                "brewer_id": brewer_id,
+            },
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -64,7 +127,7 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             email = user_input["email"]
             password = user_input["password"]
             try:
-                await _try_login(self.hass, email, password)
+                devices = await _try_login(self.hass, email, password)
             except Exception as err:
                 errors["base"] = _login_error_key(err)
                 if errors["base"] == "unknown":
@@ -72,15 +135,59 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     _LOGGER.debug("Authentication failed: %s", err)
             else:
-                await self.async_set_unique_id(email.lower())
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title=f"Fellow Aiden ({email})",
-                    data={"email": email, "password": password},
-                )
+                self._email = email
+                self._password = password
+                self._available_devices = devices
+                configured_ids = self._configured_brewer_ids()
+                available_devices = [
+                    device
+                    for device in devices
+                    if device.get("id") not in configured_ids
+                ]
+                if not available_devices:
+                    return self.async_abort(reason="all_brewers_configured")
+
+                self._available_devices = available_devices
+                if len(available_devices) == 1:
+                    return await self._async_create_device_entry(
+                        available_devices[0]
+                    )
+                return await self.async_step_device()
 
         return self.async_show_form(
             step_id="user", data_schema=USER_SCHEMA, errors=errors
+        )
+
+    async def async_step_device(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Let the user choose which unconfigured brewer to add."""
+        if not self._available_devices:
+            return self.async_abort(reason="unknown")
+
+        devices_by_id: dict[str, dict[str, Any]] = {}
+        for device in self._available_devices:
+            brewer_id = device.get("id")
+            if isinstance(brewer_id, str):
+                devices_by_id[brewer_id] = device
+        if user_input is not None:
+            selected_device = devices_by_id.get(user_input["brewer_id"])
+            if selected_device is None:
+                return self.async_abort(reason="unknown")
+            return await self._async_create_device_entry(selected_device)
+
+        return self.async_show_form(
+            step_id="device",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("brewer_id"): vol.In(
+                        {
+                            brewer_id: self._device_name(device)
+                            for brewer_id, device in devices_by_id.items()
+                        }
+                    )
+                }
+            ),
         )
 
     # -- Reauthentication ---------------------------------------------------
@@ -90,6 +197,7 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle a reauth trigger (credentials expired)."""
         self._reauth_email = entry_data["email"]
+        self._reauth_brewer_id = entry_data.get("brewer_id")
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
@@ -102,7 +210,16 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if self._reauth_email is None:
                 return self.async_abort(reason="unknown")
             try:
-                await _try_login(self.hass, self._reauth_email, password)
+                devices = await _try_login(
+                    self.hass, self._reauth_email, password
+                )
+                if self._reauth_brewer_id and not any(
+                    device.get("id") == self._reauth_brewer_id
+                    for device in devices
+                ):
+                    raise FellowNoSupportedDeviceError(
+                        "The configured brewer is not available on this account."
+                    )
             except Exception as err:
                 errors["base"] = _login_error_key(err)
                 if errors["base"] == "unknown":
@@ -110,8 +227,6 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     _LOGGER.debug("Re-authentication failed: %s", err)
             else:
-                await self.async_set_unique_id(self._reauth_email.lower())
-                self._abort_if_unique_id_mismatch(reason="wrong_account")
                 return self.async_update_reload_and_abort(
                     self._get_reauth_entry(),
                     data_updates={"password": password},
@@ -139,8 +254,16 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             email = user_input["email"]
             password = user_input["password"]
+            entry = self._get_reconfigure_entry()
+            brewer_id = entry.data.get("brewer_id")
             try:
-                await _try_login(self.hass, email, password)
+                devices = await _try_login(self.hass, email, password)
+                if brewer_id and not any(
+                    device.get("id") == brewer_id for device in devices
+                ):
+                    raise FellowNoSupportedDeviceError(
+                        "The configured brewer is not available on this account."
+                    )
             except Exception as err:
                 errors["base"] = _login_error_key(err)
                 if errors["base"] == "unknown":
@@ -148,10 +271,8 @@ class FellowAidenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     _LOGGER.debug("Reconfigure authentication failed: %s", err)
             else:
-                await self.async_set_unique_id(email.lower())
-                self._abort_if_unique_id_mismatch(reason="wrong_account")
                 return self.async_update_reload_and_abort(
-                    self._get_reconfigure_entry(),
+                    entry,
                     data_updates={"email": email, "password": password},
                 )
 

--- a/custom_components/fellow/coordinator.py
+++ b/custom_components/fellow/coordinator.py
@@ -15,25 +15,33 @@ from homeassistant.exceptions import (
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .brew_history import BrewHistoryManager
+from .const import DEFAULT_UPDATE_INTERVAL_MINUTES
 from .fellow_aiden import (
     FellowAiden,
     FellowAuthError,
     FellowConnectionError,
     FellowNoSupportedDeviceError,
 )
-from .brew_history import BrewHistoryManager
-from .const import DEFAULT_UPDATE_INTERVAL_MINUTES
 
 _LOGGER = logging.getLogger(__name__)
 
 class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator to fetch data from the Fellow Aiden cloud API."""
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, email: str, password: str) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        email: str,
+        password: str,
+        brewer_id: str | None = None,
+    ) -> None:
         """Initialize with credentials."""
         self.hass = hass
         self.email = email
         self.password = password
+        self.brewer_id = brewer_id
         self.api: FellowAiden | None = None
         self.history_manager = BrewHistoryManager(hass, entry.entry_id)
         self._next_refresh_verbose = False
@@ -54,7 +62,12 @@ class FellowAidenDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def async_config_entry_first_refresh(self) -> None:
         """Create the async API client and perform the initial refresh."""
         session = async_get_clientsession(self.hass)
-        self.api = FellowAiden(self.email, self.password, session)
+        self.api = FellowAiden(
+            self.email,
+            self.password,
+            session,
+            brewer_id=self.brewer_id,
+        )
         try:
             await self.api.authenticate()
         except FellowAuthError as err:

--- a/custom_components/fellow/fellow_aiden/__init__.py
+++ b/custom_components/fellow/fellow_aiden/__init__.py
@@ -386,6 +386,22 @@ class FellowAiden:
         """Return the brewer ID."""
         return self._brewer_id
 
+    def pin_brewer(self, brewer_id: str) -> None:
+        """Pin every subsequent refresh to a specific brewer.
+
+        Used when a legacy account-level config entry discovers its brewer on
+        the first refresh: without this, the live client stays unpinned and a
+        later refresh could fall back to another compatible Aiden.
+        """
+        if brewer_id != self._brewer_id:
+            # Cached data belongs to a different brewer; drop it so nothing is
+            # served for the newly pinned one until the next refresh.
+            self._device_config = None
+            self._profiles = None
+            self._schedules = None
+        self._configured_brewer_id = brewer_id
+        self._brewer_id = brewer_id
+
     # -- Internal helpers ---------------------------------------------------
 
     def _ordered_device_candidates(

--- a/custom_components/fellow/fellow_aiden/__init__.py
+++ b/custom_components/fellow/fellow_aiden/__init__.py
@@ -77,7 +77,11 @@ class FellowAiden:
     _MAX_RETRIES = 3
 
     def __init__(
-        self, email: str, password: str, session: aiohttp.ClientSession
+        self,
+        email: str,
+        password: str,
+        session: aiohttp.ClientSession,
+        brewer_id: str | None = None,
     ) -> None:
         """Store credentials and session.  Call ``authenticate()`` to log in."""
         self._log = logging.getLogger(self.LOGGER_NAME)
@@ -87,7 +91,8 @@ class FellowAiden:
         self._email = email
         self._password = password
         self._device_config: dict[str, Any] | None = None
-        self._brewer_id: str | None = None
+        self._configured_brewer_id = brewer_id
+        self._brewer_id: str | None = brewer_id
         self._profiles: list[dict[str, Any]] | None = None
         self._schedules: list[dict[str, Any]] | None = None
         self._session = session
@@ -202,9 +207,9 @@ class FellowAiden:
 
     # -- Authentication -----------------------------------------------------
 
-    async def authenticate(self) -> None:
-        """Authenticate and fetch initial device data."""
-        await self._do_auth(fetch_device=True)
+    async def authenticate(self, *, fetch_device: bool = True) -> None:
+        """Authenticate and optionally fetch initial device data."""
+        await self._do_auth(fetch_device=fetch_device)
 
     async def _refresh_auth(self) -> bool:
         """Attempt to refresh the access token using the stored refresh token.
@@ -266,24 +271,19 @@ class FellowAiden:
 
     async def _fetch_device(self) -> None:
         """Fetch device info from the API."""
-        self._log.debug("Fetching device for account")
-        device_url = self.BASE_URL + self.API_DEVICES
-        response = await self._request_with_reauth(
-            "get", device_url, params={"dataType": "real"}
-        )
-        await self._ensure_success(response, "Device fetch")
+        device_candidates = await self._fetch_device_candidates()
 
-        parsed = await self._parse_response(response)
-        self._log.debug(parsed)
-        if not isinstance(parsed, list):
-            raise Exception(f"Unexpected device response payload: {parsed}")
-        device_candidates = [
-            device for device in parsed if isinstance(device, dict)
-        ]
-        if not device_candidates:
-            raise FellowNoSupportedDeviceError(
-                "No supported Fellow Aiden brewer was found on this account."
-            )
+        if self._configured_brewer_id:
+            device_candidates = [
+                device
+                for device in device_candidates
+                if device.get("id") == self._configured_brewer_id
+            ]
+            if not device_candidates:
+                raise FellowNoSupportedDeviceError(
+                    f"Configured Fellow Aiden brewer {self._configured_brewer_id} "
+                    "was not found on this account."
+                )
 
         for candidate in self._ordered_device_candidates(device_candidates):
             try:
@@ -304,6 +304,45 @@ class FellowAiden:
         raise FellowNoSupportedDeviceError(
             "No supported Fellow Aiden brewer was found on this account."
         )
+
+    async def _fetch_device_candidates(self) -> list[dict[str, Any]]:
+        """Fetch all device candidates associated with the account."""
+        self._log.debug("Fetching devices for account")
+        device_url = self.BASE_URL + self.API_DEVICES
+        response = await self._request_with_reauth(
+            "get", device_url, params={"dataType": "real"}
+        )
+        await self._ensure_success(response, "Device fetch")
+
+        parsed = await self._parse_response(response)
+        self._log.debug(parsed)
+        if not isinstance(parsed, list):
+            raise Exception(f"Unexpected device response payload: {parsed}")
+        device_candidates = [
+            device for device in parsed if isinstance(device, dict)
+        ]
+        if not device_candidates:
+            raise FellowNoSupportedDeviceError(
+                "No supported Fellow Aiden brewer was found on this account."
+            )
+        return device_candidates
+
+    async def get_supported_devices(self) -> list[dict[str, Any]]:
+        """Return every compatible Aiden brewer associated with the account."""
+        supported_devices: list[dict[str, Any]] = []
+        for candidate in await self._fetch_device_candidates():
+            try:
+                await self._probe_device(candidate)
+            except _IncompatibleDeviceError as err:
+                self._log.debug("Skipping incompatible device candidate: %s", err)
+                continue
+            supported_devices.append(candidate)
+
+        if not supported_devices:
+            raise FellowNoSupportedDeviceError(
+                "No supported Fellow Aiden brewer was found on this account."
+            )
+        return supported_devices
 
     async def fetch_device(self) -> None:
         """Public method to re-fetch device data from the cloud."""

--- a/custom_components/fellow/services.yaml
+++ b/custom_components/fellow/services.yaml
@@ -2,6 +2,13 @@ create_profile:
   name: "Create Brew Profile"
   description: "Create a new brew profile on the Fellow Aiden device."
   fields:
+    config_entry_id:
+      name: "Brewer"
+      description: "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+      required: false
+      selector:
+        config_entry:
+          integration: fellow
     profile_type:
       name: "Profile Type"
       description: "Numeric profile type"
@@ -149,6 +156,13 @@ delete_profile:
   name: "Delete Brew Profile"
   description: "Delete a brew profile by ID"
   fields:
+    config_entry_id:
+      name: "Brewer"
+      description: "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+      required: false
+      selector:
+        config_entry:
+          integration: fellow
     profile_id:
       name: "Profile ID"
       description: "ID of profile to delete (e.g. 'p1')"
@@ -161,6 +175,13 @@ create_schedule:
   name: "Create Brew Schedule"
   description: "Create a new brew schedule on the Fellow Aiden device. ⚠️ WARNING: Ensure carafe/cup is in place before scheduled brew time to prevent spills!"
   fields:
+    config_entry_id:
+      name: "Brewer"
+      description: "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+      required: false
+      selector:
+        config_entry:
+          integration: fellow
     monday:
       name: "Monday"
       description: "Enable brewing on Monday"
@@ -255,6 +276,13 @@ delete_schedule:
   name: "Delete Brew Schedule"
   description: "Delete a brew schedule by its ID."
   fields:
+    config_entry_id:
+      name: "Brewer"
+      description: "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+      required: false
+      selector:
+        config_entry:
+          integration: fellow
     schedule_id:
       name: "Schedule ID"
       description: "ID of the schedule to delete."
@@ -266,6 +294,13 @@ toggle_schedule:
   name: "Enable/Disable Brew Schedule"
   description: "Enable or disable a brew schedule by its ID."
   fields:
+    config_entry_id:
+      name: "Brewer"
+      description: "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+      required: false
+      selector:
+        config_entry:
+          integration: fellow
     schedule_id:
       name: "Schedule ID"
       description: "ID of the schedule to toggle."
@@ -283,12 +318,26 @@ toggle_schedule:
 list_profiles:
   name: "List All Profiles"
   description: "Lists all available brew profiles with their names and IDs."
-  fields: {}
+  fields:
+    config_entry_id:
+      name: "Brewer"
+      description: "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+      required: false
+      selector:
+        config_entry:
+          integration: fellow
 
 get_profile_details:
   name: "Get Profile Details"
   description: "Gets detailed information about a specific profile by its name or ID."
   fields:
+    config_entry_id:
+      name: "Brewer"
+      description: "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+      required: false
+      selector:
+        config_entry:
+          integration: fellow
     profile_name:
       name: "Profile Name"
       description: "Name of the profile to get details for."
@@ -307,19 +356,47 @@ get_profile_details:
 reset_water_tracking:
   name: "Reset Water Usage Tracking"
   description: "Resets water usage tracking to start fresh. Use this if historical water sensors seem incorrect."
-  fields: {}
+  fields:
+    config_entry_id:
+      name: "Brewer"
+      description: "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+      required: false
+      selector:
+        config_entry:
+          integration: fellow
 
 list_schedules:
   name: "List All Schedules"
   description: "Lists all available brew schedules with their details."
-  fields: {}
+  fields:
+    config_entry_id:
+      name: "Brewer"
+      description: "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+      required: false
+      selector:
+        config_entry:
+          integration: fellow
 
 debug_water_usage:
   name: "Debug Water Usage"
   description: "Logs detailed water usage history for troubleshooting."
-  fields: {}
+  fields:
+    config_entry_id:
+      name: "Brewer"
+      description: "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+      required: false
+      selector:
+        config_entry:
+          integration: fellow
 
 refresh_and_log_data:
   name: "Refresh and Log Full Data"
   description: "Manually refreshes all data from the Fellow API and logs the complete response."
-  fields: {}
+  fields:
+    config_entry_id:
+      name: "Brewer"
+      description: "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+      required: false
+      selector:
+        config_entry:
+          integration: fellow

--- a/custom_components/fellow/strings.json
+++ b/custom_components/fellow/strings.json
@@ -13,6 +13,13 @@
           "password": "Your Fellow account password."
         }
       },
+      "device": {
+        "title": "Choose a Fellow Aiden",
+        "description": "Choose the brewer to add. To add another brewer from this account, run setup again.",
+        "data": {
+          "brewer_id": "Brewer"
+        }
+      },
       "reauth_confirm": {
         "title": "Re-authenticate Fellow Aiden",
         "description": "Your credentials have expired. Enter your current Fellow account password.",
@@ -43,7 +50,8 @@
       "unknown": "An unexpected error occurred."
     },
     "abort": {
-      "already_configured": "This account is already configured.",
+      "already_configured": "This brewer is already configured.",
+      "all_brewers_configured": "All supported brewers on this account are already configured.",
       "reauth_successful": "Re-authentication successful.",
       "wrong_account": "This is a different Fellow account than the one originally configured.",
       "reconfigure_successful": "Reconfiguration successful."
@@ -102,6 +110,10 @@
       "name": "Create brew profile",
       "description": "Create a new brew profile on the Fellow Aiden.",
       "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        },
         "profile_type": {
           "name": "Profile type",
           "description": "Numeric profile type."
@@ -168,6 +180,10 @@
       "name": "Delete brew profile",
       "description": "Delete a brew profile by ID.",
       "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        },
         "profile_id": {
           "name": "Profile ID",
           "description": "ID of the profile to delete (e.g. 'p1')."
@@ -178,6 +194,10 @@
       "name": "Create brew schedule",
       "description": "Create a brewing schedule. Make sure a carafe or cup is in place before the scheduled time.",
       "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        },
         "monday": { "name": "Monday", "description": "Brew on Monday." },
         "tuesday": { "name": "Tuesday", "description": "Brew on Tuesday." },
         "wednesday": { "name": "Wednesday", "description": "Brew on Wednesday." },
@@ -196,6 +216,10 @@
       "name": "Delete brew schedule",
       "description": "Delete a schedule by ID.",
       "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        },
         "schedule_id": { "name": "Schedule ID", "description": "ID of the schedule to delete." }
       }
     },
@@ -203,37 +227,75 @@
       "name": "Toggle brew schedule",
       "description": "Enable or disable a schedule.",
       "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        },
         "schedule_id": { "name": "Schedule ID", "description": "ID of the schedule." },
         "enabled": { "name": "Enabled", "description": "True to enable, false to disable." }
       }
     },
     "list_profiles": {
       "name": "List profiles",
-      "description": "Returns all brew profiles with their names and IDs."
+      "description": "Returns all brew profiles with their names and IDs.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        }
+      }
     },
     "get_profile_details": {
       "name": "Get profile details",
       "description": "Returns full details for a profile.",
       "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        },
         "profile_name": { "name": "Profile name", "description": "Name of the profile." },
         "profile_id": { "name": "Profile ID", "description": "ID of the profile (alternative to name)." }
       }
     },
     "reset_water_tracking": {
       "name": "Reset water tracking",
-      "description": "Resets the water usage baseline. Period sensors will read 0 until new usage is recorded."
+      "description": "Resets the water usage baseline. Period sensors will read 0 until new usage is recorded.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        }
+      }
     },
     "list_schedules": {
       "name": "List schedules",
-      "description": "Returns all brew schedules."
+      "description": "Returns all brew schedules.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        }
+      }
     },
     "debug_water_usage": {
       "name": "Debug water usage",
-      "description": "Returns raw water usage history for troubleshooting."
+      "description": "Returns raw water usage history for troubleshooting.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        }
+      }
     },
     "refresh_and_log_data": {
       "name": "Refresh and log data",
-      "description": "Forces a data refresh and returns the full API response."
+      "description": "Forces a data refresh and returns the full API response.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        }
+      }
     }
   },
   "exceptions": {
@@ -242,6 +304,12 @@
     },
     "not_loaded": {
       "message": "Fellow Aiden integration is not loaded. Check Settings > Integrations."
+    },
+    "target_required": {
+      "message": "Choose a Fellow Aiden config entry when more than one brewer is configured."
+    },
+    "target_not_loaded": {
+      "message": "Fellow Aiden config entry {config_entry_id} is not loaded."
     },
     "profile_id_required": {
       "message": "profile_id is required."

--- a/custom_components/fellow/translations/en.json
+++ b/custom_components/fellow/translations/en.json
@@ -13,6 +13,13 @@
           "password": "Your Fellow account password."
         }
       },
+      "device": {
+        "title": "Choose a Fellow Aiden",
+        "description": "Choose the brewer to add. To add another brewer from this account, run setup again.",
+        "data": {
+          "brewer_id": "Brewer"
+        }
+      },
       "reauth_confirm": {
         "title": "Re-authenticate Fellow Aiden",
         "description": "Your credentials have expired. Enter your current Fellow account password.",
@@ -43,7 +50,8 @@
       "unknown": "An unexpected error occurred."
     },
     "abort": {
-      "already_configured": "This account is already configured.",
+      "already_configured": "This brewer is already configured.",
+      "all_brewers_configured": "All supported brewers on this account are already configured.",
       "reauth_successful": "Re-authentication successful.",
       "wrong_account": "This is a different Fellow account than the one originally configured.",
       "reconfigure_successful": "Reconfiguration successful."
@@ -102,6 +110,10 @@
       "name": "Create brew profile",
       "description": "Create a new brew profile on the Fellow Aiden.",
       "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        },
         "profile_type": {
           "name": "Profile type",
           "description": "Numeric profile type."
@@ -168,6 +180,10 @@
       "name": "Delete brew profile",
       "description": "Delete a brew profile by ID.",
       "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        },
         "profile_id": {
           "name": "Profile ID",
           "description": "ID of the profile to delete (e.g. 'p1')."
@@ -178,6 +194,10 @@
       "name": "Create brew schedule",
       "description": "Create a brewing schedule. Make sure a carafe or cup is in place before the scheduled time.",
       "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        },
         "monday": { "name": "Monday", "description": "Brew on Monday." },
         "tuesday": { "name": "Tuesday", "description": "Brew on Tuesday." },
         "wednesday": { "name": "Wednesday", "description": "Brew on Wednesday." },
@@ -196,6 +216,10 @@
       "name": "Delete brew schedule",
       "description": "Delete a schedule by ID.",
       "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        },
         "schedule_id": { "name": "Schedule ID", "description": "ID of the schedule to delete." }
       }
     },
@@ -203,37 +227,75 @@
       "name": "Toggle brew schedule",
       "description": "Enable or disable a schedule.",
       "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        },
         "schedule_id": { "name": "Schedule ID", "description": "ID of the schedule." },
         "enabled": { "name": "Enabled", "description": "True to enable, false to disable." }
       }
     },
     "list_profiles": {
       "name": "List profiles",
-      "description": "Returns all brew profiles with their names and IDs."
+      "description": "Returns all brew profiles with their names and IDs.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        }
+      }
     },
     "get_profile_details": {
       "name": "Get profile details",
       "description": "Returns full details for a profile.",
       "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        },
         "profile_name": { "name": "Profile name", "description": "Name of the profile." },
         "profile_id": { "name": "Profile ID", "description": "ID of the profile (alternative to name)." }
       }
     },
     "reset_water_tracking": {
       "name": "Reset water tracking",
-      "description": "Resets the water usage baseline. Period sensors will read 0 until new usage is recorded."
+      "description": "Resets the water usage baseline. Period sensors will read 0 until new usage is recorded.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        }
+      }
     },
     "list_schedules": {
       "name": "List schedules",
-      "description": "Returns all brew schedules."
+      "description": "Returns all brew schedules.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        }
+      }
     },
     "debug_water_usage": {
       "name": "Debug water usage",
-      "description": "Returns raw water usage history for troubleshooting."
+      "description": "Returns raw water usage history for troubleshooting.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        }
+      }
     },
     "refresh_and_log_data": {
       "name": "Refresh and log data",
-      "description": "Forces a data refresh and returns the full API response."
+      "description": "Forces a data refresh and returns the full API response.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Brewer",
+          "description": "Fellow Aiden config entry to use. Required when multiple brewers are configured."
+        }
+      }
     }
   },
   "exceptions": {
@@ -242,6 +304,12 @@
     },
     "not_loaded": {
       "message": "Fellow Aiden integration is not loaded. Check Settings > Integrations."
+    },
+    "target_required": {
+      "message": "Choose a Fellow Aiden config entry when more than one brewer is configured."
+    },
+    "target_not_loaded": {
+      "message": "Fellow Aiden config entry {config_entry_id} is not loaded."
     },
     "profile_id_required": {
       "message": "profile_id is required."

--- a/custom_components/fellow/translations/es.json
+++ b/custom_components/fellow/translations/es.json
@@ -8,6 +8,13 @@
           "email": "Correo electrónico",
           "password": "Contraseña"
         }
+      },
+      "device": {
+        "title": "Elegir un Fellow Aiden",
+        "description": "Elige la cafetera que deseas añadir. Para añadir otra cafetera de esta cuenta, ejecuta la configuración de nuevo.",
+        "data": {
+          "brewer_id": "Cafetera"
+        }
       }
     },
     "error": {
@@ -33,6 +40,9 @@
     "error": {
       "too_fast": "El intervalo de actualización debe ser de al menos 30 segundos para evitar sobrecargar los servidores de Fellow"
     }
+  },
+  "abort": {
+    "all_brewers_configured": "Todas las cafeteras compatibles de esta cuenta ya están configuradas."
   },
   "services": {
     "create_profile": {

--- a/custom_components/fellow/translations/es.json
+++ b/custom_components/fellow/translations/es.json
@@ -22,6 +22,9 @@
       "cannot_connect": "No se pudo conectar con los servidores de Fellow. Inténtalo de nuevo más tarde.",
       "unsupported_device": "No se encontró ninguna cafetera Fellow Aiden compatible en esta cuenta.",
       "unknown": "Ocurrió un error inesperado."
+    },
+    "abort": {
+      "all_brewers_configured": "Todas las cafeteras compatibles de esta cuenta ya están configuradas."
     }
   },
   "options": {
@@ -40,9 +43,6 @@
     "error": {
       "too_fast": "El intervalo de actualización debe ser de al menos 30 segundos para evitar sobrecargar los servidores de Fellow"
     }
-  },
-  "abort": {
-    "all_brewers_configured": "Todas las cafeteras compatibles de esta cuenta ya están configuradas."
   },
   "services": {
     "create_profile": {

--- a/tests/module_loader.py
+++ b/tests/module_loader.py
@@ -126,8 +126,12 @@ def _install_voluptuous_stub() -> None:
     def Range(**_kwargs: Any) -> Any:
         return lambda value: value
 
+    def In(container: Any) -> Any:
+        return container
+
     voluptuous.All = All
     voluptuous.Coerce = Coerce
+    voluptuous.In = In
     voluptuous.Invalid = Invalid
     voluptuous.Optional = Optional
     voluptuous.Range = Range
@@ -159,6 +163,9 @@ def _install_homeassistant_stubs() -> None:
 
         def _abort_if_unique_id_mismatch(self, reason: str | None = None) -> None:
             return None
+
+        def _async_current_entries(self) -> list[Any]:
+            return []
 
         def _get_reauth_entry(self) -> dict[str, Any]:
             return {"entry_id": "reauth"}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -255,3 +255,35 @@ class ConfigFlowErrorMappingTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result["type"], "form")
         self.assertEqual(result["errors"]["base"], "unsupported_device")
+
+    async def test_reconfigure_without_brewer_id_keeps_account_check(self) -> None:
+        """Unmigrated entries fall back to the email-based account check."""
+
+        async def successful_login(
+            hass: object, email: str, password: str
+        ) -> list[dict[str, str]]:
+            del hass, email, password
+            return [{"id": "aiden-1", "displayName": "His"}]
+
+        mismatch_reasons: list[str | None] = []
+
+        with patch.object(self.module, "_try_login", new=successful_login):
+            flow = self.module.FellowAidenConfigFlow()
+            flow.hass = types.SimpleNamespace(session=object())
+            flow._get_reconfigure_entry = lambda: types.SimpleNamespace(
+                data={"email": "user@example.com", "password": "old"}
+            )
+            flow._abort_if_unique_id_mismatch = (
+                lambda reason=None: mismatch_reasons.append(reason)
+            )
+
+            result = await flow.async_step_reconfigure(
+                {
+                    "email": "Other@Example.com",
+                    "password": "secret",
+                }
+            )
+
+        self.assertEqual(mismatch_reasons, ["wrong_account"])
+        self.assertEqual(flow._unique_id, "other@example.com")
+        self.assertEqual(result["type"], "abort")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -42,3 +42,216 @@ class ConfigFlowErrorMappingTests(unittest.IsolatedAsyncioTestCase):
 
                 self.assertEqual(result["type"], "form")
                 self.assertEqual(result["errors"]["base"], expected)
+
+    async def test_multi_device_account_prompts_for_brewer(self) -> None:
+        devices = [
+            {"id": "aiden-1", "displayName": "His"},
+            {"id": "aiden-2", "displayName": "Hers"},
+        ]
+
+        async def successful_login(
+            hass: object, email: str, password: str
+        ) -> list[dict[str, str]]:
+            del hass, email, password
+            return devices
+
+        with patch.object(self.module, "_try_login", new=successful_login):
+            flow = self.module.FellowAidenConfigFlow()
+            flow.hass = types.SimpleNamespace(session=object())
+
+            result = await flow.async_step_user(
+                {"email": "user@example.com", "password": "secret"}
+            )
+            self.assertEqual(result["type"], "form")
+            self.assertEqual(result["step_id"], "device")
+
+            result = await flow.async_step_device(
+                {"brewer_id": "aiden-2"}
+            )
+
+        self.assertEqual(result["type"], "create_entry")
+        self.assertEqual(result["title"], "Hers")
+        self.assertEqual(
+            result["data"],
+            {
+                "email": "user@example.com",
+                "password": "secret",
+                "brewer_id": "aiden-2",
+            },
+        )
+        self.assertEqual(flow._unique_id, "aiden-2")
+
+    async def test_already_configured_brewer_is_filtered_out(self) -> None:
+        devices = [
+            {"id": "aiden-1", "displayName": "His"},
+            {"id": "aiden-2", "displayName": "Hers"},
+        ]
+
+        async def successful_login(
+            hass: object, email: str, password: str
+        ) -> list[dict[str, str]]:
+            del hass, email, password
+            return devices
+
+        with patch.object(self.module, "_try_login", new=successful_login):
+            flow = self.module.FellowAidenConfigFlow()
+            flow.hass = types.SimpleNamespace(session=object())
+            flow._async_current_entries = lambda: [
+                types.SimpleNamespace(
+                    data={"brewer_id": "aiden-1"},
+                    runtime_data=None,
+                )
+            ]
+
+            result = await flow.async_step_user(
+                {"email": "user@example.com", "password": "secret"}
+            )
+
+        self.assertEqual(result["type"], "create_entry")
+        self.assertEqual(result["data"]["brewer_id"], "aiden-2")
+
+    async def test_aborts_when_all_brewers_are_configured(self) -> None:
+        devices = [
+            {"id": "aiden-1", "displayName": "His"},
+            {"id": "aiden-2", "displayName": "Hers"},
+        ]
+
+        async def successful_login(
+            hass: object, email: str, password: str
+        ) -> list[dict[str, str]]:
+            del hass, email, password
+            return devices
+
+        with patch.object(self.module, "_try_login", new=successful_login):
+            flow = self.module.FellowAidenConfigFlow()
+            flow.hass = types.SimpleNamespace(session=object())
+            flow._async_current_entries = lambda: [
+                types.SimpleNamespace(
+                    data={"brewer_id": device["id"]},
+                    runtime_data=None,
+                )
+                for device in devices
+            ]
+
+            result = await flow.async_step_user(
+                {"email": "user@example.com", "password": "secret"}
+            )
+
+        self.assertEqual(
+            result,
+            {"type": "abort", "reason": "all_brewers_configured"},
+        )
+
+    async def test_runtime_brewer_id_is_filtered_out(self) -> None:
+        devices = [
+            {"id": "aiden-1", "displayName": "His"},
+            {"id": "aiden-2", "displayName": "Hers"},
+        ]
+
+        async def successful_login(
+            hass: object, email: str, password: str
+        ) -> list[dict[str, str]]:
+            del hass, email, password
+            return devices
+
+        with patch.object(self.module, "_try_login", new=successful_login):
+            flow = self.module.FellowAidenConfigFlow()
+            flow.hass = types.SimpleNamespace(session=object())
+            flow._async_current_entries = lambda: [
+                types.SimpleNamespace(
+                    data={},
+                    runtime_data=types.SimpleNamespace(
+                        api=types.SimpleNamespace(
+                            get_brewer_id=lambda: "aiden-1"
+                        )
+                    ),
+                )
+            ]
+
+            result = await flow.async_step_user(
+                {"email": "user@example.com", "password": "secret"}
+            )
+
+        self.assertEqual(result["type"], "create_entry")
+        self.assertEqual(result["data"]["brewer_id"], "aiden-2")
+
+    async def test_legacy_same_account_entry_reserves_first_brewer(self) -> None:
+        devices = [
+            {"id": "aiden-1", "displayName": "His"},
+            {"id": "aiden-2", "displayName": "Hers"},
+        ]
+
+        async def successful_login(
+            hass: object, email: str, password: str
+        ) -> list[dict[str, str]]:
+            del hass, email, password
+            return devices
+
+        with patch.object(self.module, "_try_login", new=successful_login):
+            flow = self.module.FellowAidenConfigFlow()
+            flow.hass = types.SimpleNamespace(session=object())
+            flow._async_current_entries = lambda: [
+                types.SimpleNamespace(
+                    data={"email": "USER@example.com"},
+                    runtime_data=None,
+                )
+            ]
+
+            result = await flow.async_step_user(
+                {"email": "user@example.com", "password": "secret"}
+            )
+
+        self.assertEqual(result["type"], "create_entry")
+        self.assertEqual(result["data"]["brewer_id"], "aiden-2")
+
+    async def test_reauth_rejects_account_without_configured_brewer(
+        self,
+    ) -> None:
+        async def successful_login(
+            hass: object, email: str, password: str
+        ) -> list[dict[str, str]]:
+            del hass, email, password
+            return [{"id": "aiden-1", "displayName": "His"}]
+
+        with patch.object(self.module, "_try_login", new=successful_login):
+            flow = self.module.FellowAidenConfigFlow()
+            flow.hass = types.SimpleNamespace(session=object())
+            await flow.async_step_reauth(
+                {
+                    "email": "user@example.com",
+                    "brewer_id": "aiden-2",
+                }
+            )
+
+            result = await flow.async_step_reauth_confirm(
+                {"password": "new-secret"}
+            )
+
+        self.assertEqual(result["type"], "form")
+        self.assertEqual(result["errors"]["base"], "unsupported_device")
+
+    async def test_reconfigure_rejects_account_without_configured_brewer(
+        self,
+    ) -> None:
+        async def successful_login(
+            hass: object, email: str, password: str
+        ) -> list[dict[str, str]]:
+            del hass, email, password
+            return [{"id": "aiden-1", "displayName": "His"}]
+
+        with patch.object(self.module, "_try_login", new=successful_login):
+            flow = self.module.FellowAidenConfigFlow()
+            flow.hass = types.SimpleNamespace(session=object())
+            flow._get_reconfigure_entry = lambda: types.SimpleNamespace(
+                data={"brewer_id": "aiden-2"}
+            )
+
+            result = await flow.async_step_reconfigure(
+                {
+                    "email": "other@example.com",
+                    "password": "secret",
+                }
+            )
+
+        self.assertEqual(result["type"], "form")
+        self.assertEqual(result["errors"]["base"], "unsupported_device")

--- a/tests/test_fellow_aiden.py
+++ b/tests/test_fellow_aiden.py
@@ -54,9 +54,15 @@ class FellowAidenDiscoveryTests(unittest.IsolatedAsyncioTestCase):
         self.addCleanup(cleanup)
         self.base_url = self.module.FellowAiden.BASE_URL
 
-    def _api(self, responses: dict[tuple[str, str], list[object]]):
+    def _api(
+        self,
+        responses: dict[tuple[str, str], list[object]],
+        brewer_id: str | None = None,
+    ):
         session = FakeSession(responses)
-        api = self.module.FellowAiden("user@example.com", "secret", session)
+        api = self.module.FellowAiden(
+            "user@example.com", "secret", session, brewer_id=brewer_id
+        )
         return api, session
 
     async def test_selects_first_compatible_aiden_after_skipping_incompatible_device(self) -> None:
@@ -236,4 +242,159 @@ class FellowAidenDiscoveryTests(unittest.IsolatedAsyncioTestCase):
                 ("get", f"{self.base_url}/devices/aiden-2/profiles"),
                 ("get", f"{self.base_url}/devices/aiden-2/schedules"),
             ],
+        )
+
+    async def test_discovers_every_compatible_aiden(self) -> None:
+        api, _session = self._api(
+            {
+                ("post", f"{self.base_url}/auth/login"): [
+                    FakeResponse(
+                        200,
+                        {"accessToken": "token", "refreshToken": "refresh"},
+                    )
+                ],
+                ("get", f"{self.base_url}/devices"): [
+                    FakeResponse(
+                        200,
+                        [
+                            {"id": "aiden-1", "displayName": "His"},
+                            {"id": "espresso-1", "displayName": "Espresso"},
+                            {"id": "aiden-2", "displayName": "Hers"},
+                        ],
+                    )
+                ],
+                ("get", f"{self.base_url}/devices/aiden-1/profiles"): [
+                    FakeResponse(200, [])
+                ],
+                ("get", f"{self.base_url}/devices/aiden-1/schedules"): [
+                    FakeResponse(200, [])
+                ],
+                ("get", f"{self.base_url}/devices/espresso-1/profiles"): [
+                    FakeResponse(404, {"message": "Not found"})
+                ],
+                ("get", f"{self.base_url}/devices/aiden-2/profiles"): [
+                    FakeResponse(200, [])
+                ],
+                ("get", f"{self.base_url}/devices/aiden-2/schedules"): [
+                    FakeResponse(200, [])
+                ],
+            }
+        )
+
+        await api.authenticate(fetch_device=False)
+        devices = await api.get_supported_devices()
+
+        self.assertEqual(
+            [(device["id"], device["displayName"]) for device in devices],
+            [("aiden-1", "His"), ("aiden-2", "Hers")],
+        )
+
+    async def test_configured_brewer_is_pinned_across_refreshes(self) -> None:
+        api, session = self._api(
+            {
+                ("post", f"{self.base_url}/auth/login"): [
+                    FakeResponse(
+                        200,
+                        {"accessToken": "token", "refreshToken": "refresh"},
+                    )
+                ],
+                ("get", f"{self.base_url}/devices"): [
+                    FakeResponse(
+                        200,
+                        [
+                            {"id": "aiden-1", "displayName": "His"},
+                            {"id": "aiden-2", "displayName": "Hers"},
+                        ],
+                    ),
+                    FakeResponse(
+                        200,
+                        [
+                            {"id": "aiden-1", "displayName": "His"},
+                            {"id": "aiden-2", "displayName": "Hers"},
+                        ],
+                    ),
+                ],
+                ("get", f"{self.base_url}/devices/aiden-2/profiles"): [
+                    FakeResponse(200, []),
+                    FakeResponse(200, []),
+                ],
+                ("get", f"{self.base_url}/devices/aiden-2/schedules"): [
+                    FakeResponse(200, []),
+                    FakeResponse(200, []),
+                ],
+            },
+            brewer_id="aiden-2",
+        )
+
+        await api.authenticate()
+        await api.fetch_device()
+
+        self.assertEqual(api.get_brewer_id(), "aiden-2")
+        self.assertNotIn(
+            ("get", f"{self.base_url}/devices/aiden-1/profiles"),
+            session.requests,
+        )
+
+    async def test_configured_brewer_does_not_fall_back_to_another_device(
+        self,
+    ) -> None:
+        api, session = self._api(
+            {
+                ("post", f"{self.base_url}/auth/login"): [
+                    FakeResponse(
+                        200,
+                        {"accessToken": "token", "refreshToken": "refresh"},
+                    )
+                ],
+                ("get", f"{self.base_url}/devices"): [
+                    FakeResponse(
+                        200,
+                        [{"id": "aiden-1", "displayName": "His"}],
+                    )
+                ],
+            },
+            brewer_id="aiden-2",
+        )
+
+        with self.assertRaises(self.module.FellowNoSupportedDeviceError):
+            await api.authenticate()
+
+        self.assertNotIn(
+            ("get", f"{self.base_url}/devices/aiden-1/profiles"),
+            session.requests,
+        )
+
+    async def test_incompatible_configured_brewer_does_not_fall_back(
+        self,
+    ) -> None:
+        api, session = self._api(
+            {
+                ("post", f"{self.base_url}/auth/login"): [
+                    FakeResponse(
+                        200,
+                        {"accessToken": "token", "refreshToken": "refresh"},
+                    )
+                ],
+                ("get", f"{self.base_url}/devices"): [
+                    FakeResponse(
+                        200,
+                        [
+                            {"id": "aiden-1", "displayName": "His"},
+                            {"id": "aiden-2", "displayName": "Hers"},
+                        ],
+                    )
+                ],
+                ("get", f"{self.base_url}/devices/aiden-2/profiles"): [
+                    FakeResponse(404, {"message": "Not found"})
+                ],
+            },
+            brewer_id="aiden-2",
+        )
+
+        with self.assertRaises(self.module.FellowNoSupportedDeviceError):
+            await api.authenticate()
+
+        self.assertNotIn(
+            ("get", f"{self.base_url}/devices/aiden-1/profiles"),
+            session.requests,
         )

--- a/tests/test_fellow_aiden.py
+++ b/tests/test_fellow_aiden.py
@@ -398,3 +398,44 @@ class FellowAidenDiscoveryTests(unittest.IsolatedAsyncioTestCase):
             ("get", f"{self.base_url}/devices/aiden-1/profiles"),
             session.requests,
         )
+
+    async def test_pin_brewer_prevents_fallback_to_another_aiden(self) -> None:
+        """A legacy entry that pins its discovered brewer must not fall back."""
+        api, _session = self._api(
+            {
+                ("post", f"{self.base_url}/auth/login"): [
+                    FakeResponse(
+                        200,
+                        {"accessToken": "token", "refreshToken": "refresh"},
+                    )
+                ],
+                ("get", f"{self.base_url}/devices"): [
+                    FakeResponse(
+                        200,
+                        [{"id": "aiden-1", "displayName": "His"}],
+                    ),
+                    FakeResponse(
+                        200,
+                        [{"id": "aiden-2", "displayName": "Hers"}],
+                    ),
+                ],
+                ("get", f"{self.base_url}/devices/aiden-1/profiles"): [
+                    FakeResponse(200, [])
+                ],
+                ("get", f"{self.base_url}/devices/aiden-1/schedules"): [
+                    FakeResponse(200, [])
+                ],
+            }
+        )
+
+        await api.authenticate()
+        self.assertEqual(api.get_brewer_id(), "aiden-1")
+
+        api.pin_brewer("aiden-1")
+
+        # The pinned brewer disappeared from the account; the client must
+        # report that rather than silently switching to the other Aiden.
+        with self.assertRaises(self.module.FellowNoSupportedDeviceError):
+            await api.fetch_device()
+
+        self.assertEqual(api.get_brewer_id(), "aiden-1")


### PR DESCRIPTION
## Summary

- discover every compatible Aiden on a Fellow account and let users choose which brewer to add
- create one stable Home Assistant config entry per physical brewer and filter already configured devices
- migrate existing account-level entries to a persisted brewer ID without changing their entities
- pin every refresh to the configured brewer instead of falling back to another device
- require an explicit config-entry target for service actions when multiple brewers are loaded
- document the multi-brewer setup flow and add translated UI/service fields

## Root cause

The API client stopped discovery after the first compatible Aiden, while config entries were uniquely keyed by account email. This made a second Aiden on the same account unreachable and made global service actions ambiguous once multiple entries existed.

## Validation

- `uv run -m unittest discover -s tests -v` — 19 tests pass
- Pyright — 0 errors and 0 warnings
- Python compilation and focused Ruff correctness checks
- JSON/YAML parsing and all 11 service selectors validated against the current Home Assistant package
- CodeRabbit local preflight findings verified and addressed

Ref #42
